### PR TITLE
feat: compress images client-side before upload to Cloudinary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
         "@tanstack/react-query": "^5.69.3",
+        "browser-image-compression": "^2.0.2",
         "chart.js": "^4.4.8",
         "jwt-decode": "^4.0.0",
         "moment": "^2.30.1",
@@ -4597,6 +4598,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "dependencies": {
+        "uzip": "0.20201231.0"
       }
     },
     "node_modules/browserslist": {
@@ -10030,6 +10039,11 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
     "@tanstack/react-query": "^5.69.3",
+    "browser-image-compression": "^2.0.2",
     "chart.js": "^4.4.8",
     "jwt-decode": "^4.0.0",
     "moment": "^2.30.1",

--- a/src/api/courseActions.js
+++ b/src/api/courseActions.js
@@ -1,5 +1,6 @@
 import { redirect } from "react-router-dom";
 import { getAuthToken } from "../auth/auth";
+import { compressImage } from "../util/compressImage";
 
 export async function courseAction({ request, params }) {
   const method = request.method.toUpperCase();
@@ -28,7 +29,10 @@ export async function courseAction({ request, params }) {
   const body = new FormData();
   body.append("courseData", JSON.stringify(courseData));
   const imageFile = formData.get("image");
-  if (imageFile instanceof File && imageFile.size > 0) body.append("image", imageFile);
+  if (imageFile instanceof File && imageFile.size > 0) {
+    const compressed = await compressImage(imageFile);
+    body.append("image", compressed);
+  }
 
   const url = params.courseId
     ? `${import.meta.env.VITE_DEV_URI}courses/${params.courseId}`

--- a/src/api/eventActions.js
+++ b/src/api/eventActions.js
@@ -1,5 +1,6 @@
 import { redirect } from "react-router-dom";
 import { getAuthToken } from "../auth/auth";
+import { compressImage } from "../util/compressImage";
 
 export async function eventAction({ request, params }) {
   const method = request.method;
@@ -35,7 +36,8 @@ export async function eventAction({ request, params }) {
   formData.append("eventData", JSON.stringify(eventData));
   const imageFile = data.get("image");
   if (imageFile && imageFile instanceof File && imageFile.size > 0) {
-    formData.append("image", imageFile);
+    const compressed = await compressImage(imageFile);
+    formData.append("image", compressed);
   }
 
   let url = `${import.meta.env.VITE_DEV_URI}events`;

--- a/src/pages/content/About.jsx
+++ b/src/pages/content/About.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
+import { compressImage } from "../../util/compressImage";
 
 const DEFAULT_CARDS = [
   {
@@ -121,10 +122,11 @@ export default function About() {
     setDraft({ ...draft, activityCards: cards });
   };
 
-  const handleCardImageChange = (index, file) => {
+  const handleCardImageChange = async (index, file) => {
     if (!file) return;
-    setCardImageFiles((prev) => ({ ...prev, [index]: file }));
-    setCardImagePreviews((prev) => ({ ...prev, [index]: URL.createObjectURL(file) }));
+    const compressed = await compressImage(file);
+    setCardImageFiles((prev) => ({ ...prev, [index]: compressed }));
+    setCardImagePreviews((prev) => ({ ...prev, [index]: URL.createObjectURL(compressed) }));
   };
 
   const handleSave = async () => {

--- a/src/pages/content/Home.jsx
+++ b/src/pages/content/Home.jsx
@@ -3,6 +3,7 @@ import { Link, useRouteLoaderData } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import EventCard from "../../components/events/EventCard";
 import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
+import { compressImage } from "../../util/compressImage";
 
 const DEFAULTS = {
   heroTitle: "Welcome to Ayendah Sazan",
@@ -273,11 +274,12 @@ export default function Home() {
                   type="file"
                   accept="image/*"
                   className="hidden"
-                  onChange={(e) => {
+                  onChange={async (e) => {
                     const file = e.target.files[0];
                     if (!file) return;
-                    setHeroImageFile(file);
-                    setHeroImagePreview(URL.createObjectURL(file));
+                    const compressed = await compressImage(file);
+                    setHeroImageFile(compressed);
+                    setHeroImagePreview(URL.createObjectURL(compressed));
                   }}
                 />
               </>

--- a/src/util/compressImage.js
+++ b/src/util/compressImage.js
@@ -1,0 +1,20 @@
+import imageCompression from "browser-image-compression";
+
+const OPTIONS = {
+  maxSizeMB: 0.5,
+  maxWidthOrHeight: 1280,
+  useWebWorker: true,
+};
+
+/**
+ * Compresses an image File before upload using browser-image-compression.
+ * Handles EXIF orientation, resizes to 1280px max, caps at 1MB.
+ * Falls back to the original file if compression fails.
+ */
+export async function compressImage(file, options = {}) {
+  try {
+    return await imageCompression(file, { ...OPTIONS, ...options });
+  } catch {
+    return file;
+  }
+}


### PR DESCRIPTION
Adds compressImage utility backed by browser-image-compression. Runs in a Web Worker to avoid blocking the UI, caps output at 500KB and 1280px. Handles EXIF orientation for phone uploads. Applied to all four upload points: event form, course form, home hero image, and about activity cards.