### PR TITLE
feat: add per-section reset to defaults for Home and About pages

### DIFF
--- a/src/components/common/ConfirmModal.jsx
+++ b/src/components/common/ConfirmModal.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+/**
+ * Themed confirmation modal matching the site's pink/purple glass style.
+ *
+ * Props:
+ *   isOpen    {boolean}  — whether the modal is visible
+ *   title     {string}   — bold heading
+ *   message   {string}   — body text
+ *   confirmLabel {string} — confirm button label (default "Confirm")
+ *   onConfirm {fn}       — called when the user clicks confirm
+ *   onCancel  {fn}       — called when the user clicks cancel or the backdrop
+ */
+export default function ConfirmModal({
+  isOpen,
+  title = "Are you sure?",
+  message,
+  confirmLabel = "Confirm",
+  onConfirm,
+  onCancel,
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm px-4"
+      onClick={onCancel}
+    >
+      <div
+        className="relative bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl border border-white/60 p-6 w-full max-w-sm animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Icon */}
+        <div className="flex justify-center mb-4">
+          <div className="w-12 h-12 rounded-full bg-gradient-to-br from-pink-100 to-purple-100 flex items-center justify-center shadow-inner">
+            <svg
+              className="w-6 h-6 text-purple-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.072 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
+            </svg>
+          </div>
+        </div>
+
+        {/* Text */}
+        <h3 className="text-lg font-bold text-purple-700 text-center mb-2">{title}</h3>
+        {message && (
+          <p className="text-sm text-gray-600 text-center leading-relaxed mb-6">{message}</p>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 px-4 py-2 rounded-full bg-white border border-purple-200 text-purple-600 text-sm font-medium shadow hover:bg-purple-50 hover:border-purple-300 hover:shadow-md transition-all cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-md hover:shadow-lg hover:brightness-110 transition-all cursor-pointer"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/MainNavbar.jsx
+++ b/src/components/common/MainNavbar.jsx
@@ -112,7 +112,7 @@ export default function Navbar() {
         </Link>{" "}
         {/* Hamburger Menu for Mobile */}{" "}
         <button
-          className="block lg:hidden text-pink-600 focus:outline-none bg-white/60 hover:bg-pink-100/80 rounded-full p-2 shadow-md hover:shadow-lg hover:scale-105 transition-all duration-300 cursor-pointer"
+          className="block lg:hidden text-pink-600 focus:outline-none bg-white/60 hover:bg-pink-100/80 rounded-full p-2 shadow-md hover:shadow-lg transition-all duration-300 cursor-pointer"
           onClick={(e) => {
             e.stopPropagation(); // Prevent event bubbling
 

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -170,7 +170,7 @@ export default function EventCard({ event }) {
 
           <button
             onClick={handleViewDetails}
-            className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none hover:scale-105 transition-all duration-300 shadow-md w-full cursor-pointer"
+            className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md w-full cursor-pointer"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -199,7 +199,7 @@ export default function EventCard({ event }) {
             <div className="flex gap-2 mt-2">
               <button
                 onClick={handleEditEvent}
-                className="btn btn-sm flex-1 glass border-purple-300 text-purple-700 hover:bg-purple-100/30 hover:scale-105 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
+                className="btn btn-sm flex-1 glass border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
                 title="Edit Event"
               >
                 <svg
@@ -220,7 +220,7 @@ export default function EventCard({ event }) {
               </button>
               <button
                 onClick={handleRemoveEvent}
-                className="btn btn-sm flex-1 bg-red-100/50 border-red-300 text-red-700 hover:bg-red-200/50 hover:scale-105 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
+                className="btn btn-sm flex-1 bg-red-100/50 border-red-300 text-red-700 hover:bg-red-200/50 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
                 title="Remove Event"
               >
                 <svg

--- a/src/components/events/EventHeader.jsx
+++ b/src/components/events/EventHeader.jsx
@@ -38,7 +38,7 @@ const EventHeader = () => {
         </div>
         <NavLink
           to="/events/new"
-          className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-md shadow-pink-200/50 hover:scale-105 transition-all cursor-pointer"
+          className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-md shadow-pink-200/50 transition-all cursor-pointer"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />

--- a/src/components/events/RecurringEventsCalendar.jsx
+++ b/src/components/events/RecurringEventsCalendar.jsx
@@ -27,7 +27,7 @@ const CustomToolbar = (toolbar) => {
       <div className="flex items-center gap-2">
         <button
           onClick={goToBack}
-          className="w-9 h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-pink-50 border border-pink-200/50 text-pink-500 hover:text-pink-600 hover:scale-105 transition-all shadow-sm cursor-pointer"
+          className="w-9 h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-pink-50 border border-pink-200/50 text-pink-500 hover:text-pink-600 transition-all shadow-sm cursor-pointer"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -44,13 +44,13 @@ const CustomToolbar = (toolbar) => {
         </button>
         <button
           onClick={goToCurrent}
-          className="px-4 h-9 rounded-xl bg-white/60 hover:bg-purple-50 border border-purple-200/50 text-purple-600 text-sm font-medium hover:scale-105 transition-all shadow-sm cursor-pointer"
+          className="px-4 h-9 rounded-xl bg-white/60 hover:bg-purple-50 border border-purple-200/50 text-purple-600 text-sm font-medium transition-all shadow-sm cursor-pointer"
         >
           Today
         </button>
         <button
           onClick={goToNext}
-          className="w-9 h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-pink-50 border border-pink-200/50 text-pink-500 hover:text-pink-600 hover:scale-105 transition-all shadow-sm cursor-pointer"
+          className="w-9 h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-pink-50 border border-pink-200/50 text-pink-500 hover:text-pink-600 transition-all shadow-sm cursor-pointer"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -393,7 +393,7 @@ export default function RecurringEventsCalendar({ events, title = "Events Calend
                 </button>
                 <button
                   onClick={handleConfirmNavigate}
-                  className="flex-1 py-2 rounded-xl bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium hover:scale-105 transition-all shadow-sm cursor-pointer"
+                  className="flex-1 py-2 rounded-xl bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium transition-all shadow-sm cursor-pointer"
                 >
                   View Details →
                 </button>

--- a/src/components/teams/TeamSignupForm.jsx
+++ b/src/components/teams/TeamSignupForm.jsx
@@ -139,7 +139,7 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
                     <button
                       onClick={() => handleResumeTeam(team)}
                       disabled={loading}
-                      className="btn btn-sm bg-gradient-to-r from-amber-400 to-orange-500 border-none text-white hover:scale-105 transition-all duration-300 rounded-lg text-xs"
+                      className="btn btn-sm bg-gradient-to-r from-amber-400 to-orange-500 border-none text-white transition-all duration-300 rounded-lg text-xs"
                     >
                       Resume & Pay
                     </button>
@@ -220,7 +220,7 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
                   {members.length > 1 && (
                     <button
                       type="button"
-                      className="btn btn-sm bg-white/50 hover:bg-red-100/60 border border-red-200/50 text-red-500 hover:text-red-700 rounded-lg hover:scale-105 transition-all duration-300"
+                      className="btn btn-sm bg-white/50 hover:bg-red-100/60 border border-red-200/50 text-red-500 hover:text-red-700 rounded-lg transition-all duration-300"
                       onClick={() => removeMember(idx)}
                     >
                       <svg
@@ -244,7 +244,7 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
             </div>
             <button
               type="button"
-              className="btn btn-sm bg-purple-100/60 hover:bg-purple-200/60 border border-purple-200/60 text-purple-700 hover:scale-105 transition-all duration-300 rounded-lg"
+              className="btn btn-sm bg-purple-100/60 hover:bg-purple-200/60 border border-purple-200/60 text-purple-700 transition-all duration-300 rounded-lg"
               onClick={addMember}
             >
               <svg
@@ -266,7 +266,7 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
           </div>
 
           <button
-            className="btn bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white border-none hover:scale-105 transition-all duration-300 shadow-md w-full rounded-xl py-3"
+            className="btn bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white border-none transition-all duration-300 shadow-md w-full rounded-xl py-3"
             type="submit"
             disabled={loading}
           >

--- a/src/pages/Errorpage.jsx
+++ b/src/pages/Errorpage.jsx
@@ -29,7 +29,7 @@ export default function ErrorPage({ error }) {
           </div>
         )}
         <button
-          className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none hover:scale-105 transition-all duration-300 shadow-md"
+          className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md"
           onClick={() => (window.location.href = "/")}
         >
           Return to Home

--- a/src/pages/content/About.jsx
+++ b/src/pages/content/About.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
 import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
 import { compressImage } from "../../util/compressImage";
+import { Link } from "react-router-dom";
+import ConfirmModal from "../../components/common/ConfirmModal";
 
 const DEFAULT_CARDS = [
   {
@@ -42,6 +44,20 @@ const DEFAULTS = {
     "Join us in making a difference! Whether you want to volunteer, attend an event, or support our initiatives, there are many ways to get involved with Ayendah Sazan.",
 };
 
+function mergeWithDefaults(saved) {
+  return {
+    ...DEFAULTS,
+    ...saved,
+    activityCards: saved.activityCards?.length
+      ? saved.activityCards.map((c, i) => ({
+          ...DEFAULT_CARDS[i],
+          ...c,
+          image: c.image || DEFAULT_CARDS[i].image,
+        }))
+      : DEFAULTS.activityCards,
+  };
+}
+
 function EditableField({ editing, value, onChange, className, multiline, placeholder, rows = 3 }) {
   if (!editing)
     return multiline ? (
@@ -71,6 +87,13 @@ function EditableField({ editing, value, onChange, className, multiline, placeho
   );
 }
 
+const SECTION_LABELS = {
+  hero: "the hero section",
+  cards: "all activity cards",
+  mission: "the mission section",
+  getInvolved: "the Get Involved section",
+};
+
 export default function About() {
   const canEdit = isAdmin() || isModerator();
 
@@ -80,7 +103,9 @@ export default function About() {
   const [cardImageFiles, setCardImageFiles] = useState({});
   const [cardImagePreviews, setCardImagePreviews] = useState({});
   const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
   const [saveError, setSaveError] = useState(null);
+  const [pendingReset, setPendingReset] = useState(null); // section key or "all"
   const cardImageRefs = useRef([]);
 
   useEffect(() => {
@@ -88,13 +113,7 @@ export default function About() {
       .then((r) => r.json())
       .then((data) => {
         if (data && Object.keys(data).length > 0) {
-          const merged = {
-            ...DEFAULTS,
-            ...data,
-            activityCards: data.activityCards?.length
-              ? data.activityCards.map((c, i) => ({ ...DEFAULT_CARDS[i], ...c }))
-              : DEFAULTS.activityCards,
-          };
+          const merged = mergeWithDefaults(data);
           setPageContent(merged);
           setDraft(merged);
         }
@@ -115,6 +134,50 @@ export default function About() {
     setCardImageFiles({});
     setCardImagePreviews({});
     setSaveError(null);
+  };
+
+  const resetSection = (section) => setPendingReset(section);
+
+  const doReset = async () => {
+    const section = pendingReset;
+    setPendingReset(null);
+    setResetting(true);
+    setSaveError(null);
+    try {
+      const token = getAuthToken();
+      const url =
+        section === "all"
+          ? `${import.meta.env.VITE_DEV_URI}pageContent/about`
+          : `${import.meta.env.VITE_DEV_URI}pageContent/about/${section}`;
+
+      const res = await fetch(url, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message || `Server error (${res.status})`);
+      }
+
+      const data = await res.json();
+      if (section === "all") {
+        setPageContent(DEFAULTS);
+        setDraft(DEFAULTS);
+        setEditing(false);
+      } else {
+        const merged = mergeWithDefaults(data.pageContent || {});
+        setPageContent(merged);
+        setDraft(JSON.parse(JSON.stringify(merged)));
+        if (section === "cards") {
+          setCardImageFiles({});
+          setCardImagePreviews({});
+        }
+      }
+    } catch (err) {
+      setSaveError(err.message || "Failed to reset. Please try again.");
+    } finally {
+      setResetting(false);
+    }
   };
 
   const updateCard = (index, field, value) => {
@@ -180,14 +243,7 @@ export default function About() {
         throw new Error(body?.message || `Server error (${res.status})`);
       }
       const { pageContent: saved } = await res.json();
-      const merged = {
-        ...DEFAULTS,
-        ...saved,
-        activityCards: saved.activityCards?.length
-          ? saved.activityCards.map((c, i) => ({ ...DEFAULT_CARDS[i], ...c }))
-          : DEFAULTS.activityCards,
-      };
-      setPageContent(merged);
+      setPageContent(mergeWithDefaults(saved));
       setEditing(false);
       setCardImageFiles({});
       setCardImagePreviews({});
@@ -198,15 +254,26 @@ export default function About() {
     }
   };
 
+  const resetLabel =
+    pendingReset === "all" ? "the entire about page" : SECTION_LABELS[pendingReset];
+
   return (
     <div className="container mx-auto p-6">
+      <ConfirmModal
+        isOpen={!!pendingReset}
+        title="Reset to Defaults?"
+        message={`Reset ${resetLabel} to default content? This will permanently clear any custom text and images for that section.`}
+        confirmLabel="Reset"
+        onConfirm={doReset}
+        onCancel={() => setPendingReset(null)}
+      />
       {/* ── Edit toolbar ── */}
       {canEdit && (
         <div className="sticky top-16 z-40 flex justify-end gap-2 -mx-6 px-6 py-2 mb-4 bg-white/60 backdrop-blur-sm border-b border-white/40">
           {!editing ? (
             <button
               onClick={handleEdit}
-              className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 hover:scale-105 transition-all"
+              className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 transition-all cursor-pointer"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
@@ -222,14 +289,21 @@ export default function About() {
             <>
               <button
                 onClick={handleCancel}
-                className="px-4 py-2 rounded-full bg-white border border-gray-200 text-gray-600 text-sm font-medium shadow hover:bg-gray-50 transition-all"
+                className="px-4 py-2 rounded-full bg-white border border-purple-200 text-purple-600 text-sm font-medium shadow hover:bg-purple-50 hover:border-purple-300 hover:shadow-md transition-all cursor-pointer"
               >
                 Cancel
               </button>
               <button
+                onClick={() => resetSection("all")}
+                disabled={resetting}
+                className="flex items-center gap-2 px-4 py-2 rounded-full bg-white border border-amber-300 text-amber-700 text-sm font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
+              >
+                {resetting ? "Resetting…" : "Reset All to Defaults"}
+              </button>
+              <button
                 onClick={handleSave}
                 disabled={saving}
-                className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 hover:scale-105 transition-all disabled:opacity-60"
+                className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 transition-all disabled:opacity-60 cursor-pointer"
               >
                 {saving ? "Saving…" : "Save Changes"}
               </button>
@@ -292,6 +366,13 @@ export default function About() {
               value={draft.aboutHeroDescription}
               onChange={(e) => setDraft({ ...draft, aboutHeroDescription: e.target.value })}
             />
+            <button
+              onClick={() => resetSection("hero")}
+              disabled={resetting}
+              className="mt-3 px-3 py-1.5 rounded-full bg-white border border-amber-300 text-amber-700 text-xs font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
+            >
+              Reset to Defaults
+            </button>
           </>
         ) : (
           <>
@@ -305,7 +386,18 @@ export default function About() {
 
       {/* ── What We Do ── */}
       <div className="mb-12">
-        <h2 className="text-3xl font-bold text-secondary mb-6 text-center">What We Do</h2>
+        <div className="flex items-center justify-center gap-3 mb-6">
+          <h2 className="text-3xl font-bold text-secondary">What We Do</h2>
+          {editing && (
+            <button
+              onClick={() => resetSection("cards")}
+              disabled={resetting}
+              className="px-3 py-1.5 rounded-full bg-white border border-amber-300 text-amber-700 text-xs font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
+            >
+              Reset to Defaults
+            </button>
+          )}
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
           {(editing ? draft.activityCards : pageContent.activityCards).map((card, i) => {
             const imgSrc = cardImagePreviews[i] || card.image;
@@ -324,7 +416,7 @@ export default function About() {
                     <>
                       <button
                         onClick={() => cardImageRefs.current[i]?.click()}
-                        className="absolute top-3 right-3 flex items-center gap-1.5 px-3 py-1.5 bg-white/90 rounded-full text-xs font-medium text-purple-700 shadow hover:bg-white transition-all"
+                        className="absolute top-3 right-3 flex items-center gap-1.5 px-3 py-1.5 bg-white/90 rounded-full text-xs font-medium text-purple-700 shadow hover:bg-white transition-all cursor-pointer"
                       >
                         <svg
                           className="w-3.5 h-3.5"
@@ -396,6 +488,13 @@ export default function About() {
               value={draft.missionText}
               onChange={(e) => setDraft({ ...draft, missionText: e.target.value })}
             />
+            <button
+              onClick={() => resetSection("mission")}
+              disabled={resetting}
+              className="mt-3 px-3 py-1.5 rounded-full bg-white border border-amber-300 text-amber-700 text-xs font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
+            >
+              Reset to Defaults
+            </button>
           </>
         ) : (
           <>
@@ -422,6 +521,13 @@ export default function About() {
               value={draft.getInvolvedText}
               onChange={(e) => setDraft({ ...draft, getInvolvedText: e.target.value })}
             />
+            <button
+              onClick={() => resetSection("getInvolved")}
+              disabled={resetting}
+              className="mb-4 px-3 py-1.5 rounded-full bg-white border border-amber-300 text-amber-700 text-xs font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
+            >
+              Reset to Defaults
+            </button>
           </>
         ) : (
           <>
@@ -431,12 +537,12 @@ export default function About() {
             <p className="text-lg text-gray-700 mb-6">{pageContent.getInvolvedText}</p>
           </>
         )}
-        <a
-          href="/contact"
-          className="inline-block btn btn-primary px-6 py-3 text-white rounded-xl shadow-md hover:scale-105 hover:bg-pink-400 transition-all"
+        <Link
+          to="/contact"
+          className="inline-block bg-gradient-to-r from-pink-500 to-purple-600 text-white px-6 py-3 rounded-full font-semibold shadow-lg shadow-pink-200 transition-all"
         >
           Contact Us
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/content/Contact.jsx
+++ b/src/pages/content/Contact.jsx
@@ -152,7 +152,7 @@ export default function Contact() {
             <div className="text-center">
               <button
                 type="submit"
-                className="w-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold py-3 rounded-xl hover:scale-105 transition-all duration-300 shadow-md cursor-pointer"
+                className="w-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-semibold py-3 rounded-xl transition-all duration-300 shadow-md cursor-pointer"
                 disabled={isSubmitting}
               >
                 {isSubmitting ? "Sending..." : "Send Message"}

--- a/src/pages/content/Home.jsx
+++ b/src/pages/content/Home.jsx
@@ -4,6 +4,7 @@ import { Helmet } from "react-helmet-async";
 import EventCard from "../../components/events/EventCard";
 import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
 import { compressImage } from "../../util/compressImage";
+import ConfirmModal from "../../components/common/ConfirmModal";
 
 const DEFAULTS = {
   heroTitle: "Welcome to Ayendah Sazan",
@@ -12,6 +13,10 @@ const DEFAULTS = {
   heroBadgeText: "Inspiring Communities",
   heroImage: "/heroImage.jpg",
 };
+
+function mergeWithDefaults(saved) {
+  return { ...DEFAULTS, ...saved, heroImage: saved.heroImage || DEFAULTS.heroImage };
+}
 
 export default function Home() {
   const { events } = useRouteLoaderData("root");
@@ -23,7 +28,9 @@ export default function Home() {
   const [heroImagePreview, setHeroImagePreview] = useState(null);
   const [heroImageFile, setHeroImageFile] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
   const [saveError, setSaveError] = useState(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const heroImageInputRef = useRef(null);
 
   useEffect(() => {
@@ -31,7 +38,7 @@ export default function Home() {
       .then((r) => r.json())
       .then((data) => {
         if (data && Object.keys(data).length > 0) {
-          const merged = { ...DEFAULTS, ...data };
+          const merged = mergeWithDefaults(data);
           setPageContent(merged);
           setDraft(merged);
         }
@@ -52,6 +59,34 @@ export default function Home() {
     setHeroImagePreview(null);
     setHeroImageFile(null);
     setSaveError(null);
+  };
+
+  const handleResetDefaults = () => setConfirmOpen(true);
+
+  const doReset = async () => {
+    setConfirmOpen(false);
+    setResetting(true);
+    setSaveError(null);
+    try {
+      const token = getAuthToken();
+      const res = await fetch(`${import.meta.env.VITE_DEV_URI}pageContent/home`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.message || `Server error (${res.status})`);
+      }
+      setPageContent(DEFAULTS);
+      setDraft(DEFAULTS);
+      setHeroImagePreview(null);
+      setHeroImageFile(null);
+      setEditing(false);
+    } catch (err) {
+      setSaveError(err.message || "Failed to reset. Please try again.");
+    } finally {
+      setResetting(false);
+    }
   };
 
   const handleSave = async () => {
@@ -91,7 +126,7 @@ export default function Home() {
         throw new Error(body?.message || `Server error (${res.status})`);
       }
       const { pageContent: saved } = await res.json();
-      const merged = { ...DEFAULTS, ...saved };
+      const merged = mergeWithDefaults(saved);
       setPageContent(merged);
       setEditing(false);
       setHeroImagePreview(null);
@@ -108,6 +143,14 @@ export default function Home() {
 
   return (
     <div className="bg-gradient-to-tr from-pink-100 via-purple-100 to-indigo-100 min-h-screen">
+      <ConfirmModal
+        isOpen={confirmOpen}
+        title="Reset to Defaults?"
+        message="This will permanently clear all custom text and images on the home page."
+        confirmLabel="Reset"
+        onConfirm={doReset}
+        onCancel={() => setConfirmOpen(false)}
+      />
       <Helmet>
         <title>Ayendah Sazan - Home</title>
         <meta name="description" content={pageContent.heroDescription} />
@@ -115,11 +158,11 @@ export default function Home() {
 
       {/* ── Edit toolbar ── */}
       {canEdit && (
-        <div className="sticky top-16 mt-6 z-40 flex justify-end gap-2 -mx-4 px-6 py-2 mb-4 bg-white/60 backdrop-blur-sm border-b border-white/40">
+        <div className="sticky top-16 mt-6 z-40 flex justify-end gap-2 px-6 py-2 mb-4 bg-white/60 backdrop-blur-sm border-b border-white/40">
           {!editing ? (
             <button
               onClick={handleEdit}
-              className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 hover:scale-105 transition-all cursor-pointer"
+              className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 transition-all cursor-pointer"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
@@ -135,14 +178,21 @@ export default function Home() {
             <>
               <button
                 onClick={handleCancel}
-                className="px-4 py-2 rounded-full bg-white border border-gray-200 text-gray-600 text-sm font-medium shadow hover:bg-gray-50 transition-all cursor-pointer"
+                className="px-4 py-2 rounded-full bg-white border border-purple-200 text-purple-600 text-sm font-medium shadow hover:bg-purple-50 hover:border-purple-300 hover:shadow-md transition-all cursor-pointer"
               >
                 Cancel
               </button>
               <button
+                onClick={handleResetDefaults}
+                disabled={resetting}
+                className="flex items-center gap-2 px-4 py-2 rounded-full bg-white border border-amber-300 text-amber-700 text-sm font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
+              >
+                {resetting ? "Resetting…" : "Reset to Defaults"}
+              </button>
+              <button
                 onClick={handleSave}
                 disabled={saving}
-                className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 hover:scale-105 transition-all disabled:opacity-60 cursor-pointer"
+                className="flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow-lg shadow-pink-200 transition-all disabled:opacity-60 cursor-pointer"
               >
                 {saving ? "Saving…" : "Save Changes"}
               </button>
@@ -224,13 +274,11 @@ export default function Home() {
             <Link
               to="/about"
               aria-label="Learn more about Ayendah Sazan"
-              className="inline-block bg-gradient-to-r from-pink-500 to-purple-600 text-white px-6 py-3 text-base rounded-xl shadow-md hover:scale-105 transition-all duration-300"
+              className="inline-block bg-gradient-to-r from-pink-500 to-purple-600 text-white px-6 py-3 rounded-full font-semibold shadow-lg shadow-pink-200 transition-all"
             >
               Learn More
             </Link>
           </div>
-
-          {/* Image */}
           <div
             className={`relative w-full max-w-sm md:max-w-md lg:max-w-lg transition-all duration-500 ${!editing ? "transform hover:rotate-1" : ""}`}
           >

--- a/src/pages/courses/CourseConfirmation.jsx
+++ b/src/pages/courses/CourseConfirmation.jsx
@@ -87,7 +87,7 @@ export default function CourseConfirmation() {
         <div className="flex flex-col sm:flex-row gap-3">
           <Link
             to="/profile"
-            className="flex-1 btn bg-gradient-to-r from-purple-500 to-pink-500 border-none text-white hover:scale-105 transition-all rounded-xl shadow-md"
+            className="flex-1 btn bg-gradient-to-r from-purple-500 to-pink-500 border-none text-white transition-all rounded-xl shadow-md"
           >
             View My Profile
           </Link>

--- a/src/pages/courses/CourseDetails.jsx
+++ b/src/pages/courses/CourseDetails.jsx
@@ -441,7 +441,7 @@ export default function CourseDetails() {
                     <button
                       onClick={handleEnroll}
                       disabled={isProcessing}
-                      className="btn bg-gradient-to-r from-pink-500 to-purple-600 w-full border-none text-white hover:scale-105 transition-all duration-300 shadow-md rounded-xl"
+                      className="btn bg-gradient-to-r from-pink-500 to-purple-600 w-full border-none text-white transition-all duration-300 shadow-md rounded-xl"
                     >
                       {isProcessing ? (
                         <span className="flex items-center justify-center gap-2">
@@ -490,7 +490,7 @@ export default function CourseDetails() {
         <div className="mt-8">
           <button
             onClick={() => navigate(-1)}
-            className="btn glass border border-purple-300 text-purple-700 hover:bg-purple-100/30 hover:scale-105 transition-all duration-300 rounded-xl"
+            className="btn glass border border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300 rounded-xl"
           >
             <svg className="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path

--- a/src/pages/courses/Courses.jsx
+++ b/src/pages/courses/Courses.jsx
@@ -41,7 +41,7 @@ export default function CoursesPage() {
             <p className="text-sm text-purple-700 font-medium">Manage Courses</p>
             <Link
               to="/courses/new"
-              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow hover:scale-105 transition-all"
+              className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-pink-500 to-purple-600 text-white text-sm font-medium shadow transition-all"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path

--- a/src/pages/events/EventDetails.jsx
+++ b/src/pages/events/EventDetails.jsx
@@ -444,7 +444,7 @@ export default function EventDetails() {
 
                     <div className="pt-2">
                       <button
-                        className="btn bg-gradient-to-r from-pink-500 to-purple-600 w-full border-none text-white hover:scale-105 transition-all duration-300 shadow-md rounded-xl"
+                        className="btn bg-gradient-to-r from-pink-500 to-purple-600 w-full border-none text-white transition-all duration-300 shadow-md rounded-xl"
                         onClick={handleBuyTickets}
                         disabled={isProcessing || event.ticketsAvailable === 0}
                       >
@@ -519,7 +519,7 @@ export default function EventDetails() {
         {/* Back Button */}
         <div className="mt-8 mb-4">
           <button
-            className="btn glass border border-purple-300 text-purple-700 hover:bg-purple-100/30 hover:scale-105 transition-all duration-300"
+            className="btn glass border border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300"
             onClick={handleBack}
           >
             <svg

--- a/src/pages/payments/CancelPage.jsx
+++ b/src/pages/payments/CancelPage.jsx
@@ -31,7 +31,7 @@ export default function CancelPage() {
           Your transaction has been cancelled. If this was a mistake, you can try again.
         </p>
         <button
-          className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none hover:scale-105 transition-all duration-300 shadow-md"
+          className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md"
           onClick={handleGoBack}
         >
           Go Back to Home

--- a/src/pages/payments/OrderConfirmation.jsx
+++ b/src/pages/payments/OrderConfirmation.jsx
@@ -146,7 +146,7 @@ export default function OrderConfirmation() {
           <div className="space-y-3">
             <Link
               to="/profile"
-              className="block w-full px-6 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-xl hover:scale-105 transition-all font-medium"
+              className="block w-full px-6 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-xl transition-all font-medium"
             >
               View My Tickets
             </Link>
@@ -208,7 +208,7 @@ export default function OrderConfirmation() {
         <div className="space-y-3">
           <button
             onClick={() => window.print()}
-            className="w-full btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none hover:scale-105 transition-all duration-300 shadow-md"
+            className="w-full btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -228,7 +228,7 @@ export default function OrderConfirmation() {
           </button>
           <button
             onClick={handleAddToCalendar}
-            className="w-full btn glass border border-purple-300 text-purple-700 hover:bg-purple-100/30 hover:scale-105 transition-all duration-300"
+            className="w-full btn glass border border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -248,7 +248,7 @@ export default function OrderConfirmation() {
           </button>
           <Link
             to="/profile"
-            className="block text-center w-full btn glass border border-gray-300 text-gray-700 hover:bg-gray-100/30 hover:scale-105 transition-all duration-300"
+            className="block text-center w-full btn glass border border-gray-300 text-gray-700 hover:bg-gray-100/30 transition-all duration-300"
           >
             View All Tickets
           </Link>

--- a/src/pages/teams/TeamConfirmationPage.jsx
+++ b/src/pages/teams/TeamConfirmationPage.jsx
@@ -178,7 +178,7 @@ export default function TeamConfirmationPage() {
             <div className="flex flex-col sm:flex-row gap-3 pt-2">
               <Link
                 to="/profile"
-                className="flex-1 btn bg-gradient-to-r from-purple-500 to-pink-500 border-none text-white hover:scale-105 transition-all duration-300 rounded-xl shadow-md"
+                className="flex-1 btn bg-gradient-to-r from-purple-500 to-pink-500 border-none text-white transition-all duration-300 rounded-xl shadow-md"
               >
                 View My Profile
               </Link>
@@ -186,14 +186,14 @@ export default function TeamConfirmationPage() {
                 <Link
                   to={`/events/${toSlug(event.title, event._id)}`}
                   aria-label={`View ${event.title} tournament`}
-                  className="flex-1 btn bg-white/60 border border-purple-200 text-purple-700 hover:bg-white/80 hover:scale-105 transition-all duration-300 rounded-xl"
+                  className="flex-1 btn bg-white/60 border border-purple-200 text-purple-700 hover:bg-white/80 transition-all duration-300 rounded-xl"
                 >
                   View Tournament
                 </Link>
               )}
               <Link
                 to="/"
-                className="flex-1 btn bg-white/60 border border-purple-200 text-purple-700 hover:bg-white/80 hover:scale-105 transition-all duration-300 rounded-xl"
+                className="flex-1 btn bg-white/60 border border-purple-200 text-purple-700 hover:bg-white/80 transition-all duration-300 rounded-xl"
               >
                 Return to Home
               </Link>

--- a/src/pages/tickets/TicketVerify.jsx
+++ b/src/pages/tickets/TicketVerify.jsx
@@ -194,7 +194,7 @@ export default function TicketVerify() {
                     <button
                       onClick={() => checkInMutation.mutate()}
                       disabled={checkInMutation.isPending}
-                      className="w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold py-4 px-6 rounded-2xl text-lg shadow-lg transition-all duration-200 transform hover:scale-105 active:scale-95"
+                      className="w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold py-4 px-6 rounded-2xl text-lg shadow-lg transition-all duration-200 active:scale-95"
                     >
                       {checkInMutation.isPending ? "Checking In..." : "✓ Check In"}
                     </button>


### PR DESCRIPTION
- Add ConfirmModal component with pink/purple glass theme for confirmations
- Home page: toolbar + inline reset button that calls DELETE /pageContent/home
- About page: toolbar reset-all + inline per-section reset buttons calling DELETE /pageContent/about/:section with Cloudinary image cleanup
- Fix mergeWithDefaults to handle null image fields returned after DB reset
- Remove hover:scale-105 site-wide to fix GPU-composited text pixellation