### PR TITLE
feat: design improvements — rich footer, auth cross-links, home stats…

### DIFF
--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -1,8 +1,140 @@
 import React from "react";
+import { Link } from "react-router-dom";
+
 export default function Footer() {
+  const year = new Date().getFullYear();
+
   return (
-    <footer className="bg-gradient-to-r from-purple-900 via-indigo-900 to-pink-900 text-white text-center p-4 mt-10">
-      <p>&copy; {new Date().getFullYear()} Ayendah Sazan. All rights reserved.</p>
+    <footer className="bg-gradient-to-br from-slate-900 via-purple-950 to-indigo-950 text-white mt-10">
+      {/* Main footer grid */}
+      <div className="container mx-auto px-6 py-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
+        {/* Brand */}
+        <div className="lg:col-span-1">
+          <div className="flex items-center gap-2 mb-4">
+            <div className="w-9 h-9 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm shadow-lg shadow-pink-500/30">
+              ASC
+            </div>
+            <span className="text-lg font-bold bg-gradient-to-r from-pink-400 to-purple-300 bg-clip-text text-transparent">
+              Ayendah Sazan
+            </span>
+          </div>
+          <p className="text-sm text-slate-400 leading-relaxed">
+            A community-based organisation in Leeds dedicated to bringing people together through
+            cultural, educational, and sporting events.
+          </p>
+        </div>
+
+        {/* Quick links */}
+        <div>
+          <h3 className="text-sm font-semibold text-white uppercase tracking-widest mb-4">
+            Quick Links
+          </h3>
+          <ul className="space-y-2 text-sm text-slate-400">
+            {[
+              { to: "/", label: "Home" },
+              { to: "/about", label: "About Us" },
+              { to: "/contact", label: "Contact" },
+            ].map(({ to, label }) => (
+              <li key={to}>
+                <Link
+                  to={to}
+                  className="hover:text-pink-400 transition-colors duration-200 flex items-center gap-1.5 group"
+                >
+                  <span className="w-1 h-1 rounded-full bg-purple-500 group-hover:bg-pink-400 transition-colors" />
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Programmes */}
+        <div>
+          <h3 className="text-sm font-semibold text-white uppercase tracking-widest mb-4">
+            Programmes
+          </h3>
+          <ul className="space-y-2 text-sm text-slate-400">
+            {[
+              { to: "/events/asc", label: "ASC Events" },
+              { to: "/events/sports", label: "Sports Events" },
+              { to: "/courses", label: "Courses" },
+            ].map(({ to, label }) => (
+              <li key={to}>
+                <Link
+                  to={to}
+                  className="hover:text-pink-400 transition-colors duration-200 flex items-center gap-1.5 group"
+                >
+                  <span className="w-1 h-1 rounded-full bg-purple-500 group-hover:bg-pink-400 transition-colors" />
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Contact */}
+        <div>
+          <h3 className="text-sm font-semibold text-white uppercase tracking-widest mb-4">
+            Get in Touch
+          </h3>
+          <ul className="space-y-3 text-sm text-slate-400">
+            <li className="flex items-start gap-2">
+              <svg
+                className="w-4 h-4 mt-0.5 text-pink-400 flex-shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              <span>Leeds, United Kingdom</span>
+            </li>
+            <li>
+              <Link
+                to="/contact"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-gradient-to-r from-pink-500/20 to-purple-500/20 hover:from-pink-500/40 hover:to-purple-500/40 border border-pink-500/30 text-pink-300 text-xs font-medium transition-all duration-200"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                  />
+                </svg>
+                Send us a message
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-white/10" />
+
+      {/* Bottom bar */}
+      <div className="container mx-auto px-6 py-4 flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-slate-500">
+        <p>&copy; {year} Ayendah Sazan Community Organisation. All rights reserved.</p>
+        <div className="flex items-center gap-4">
+          <Link to="/about" className="hover:text-slate-300 transition-colors">
+            About
+          </Link>
+          <Link to="/contact" className="hover:text-slate-300 transition-colors">
+            Contact
+          </Link>
+        </div>
+      </div>
     </footer>
   );
 }

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,13 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { useNavigate, useRouteLoaderData } from "react-router-dom";
 import { isAdmin, isModerator } from "../../auth/auth";
-
 import { formatDateRange, optimizeCloudinaryUrl, toSlug } from "../../util/util";
+import ConfirmModal from "../common/ConfirmModal";
 
 export default function EventCard({ event }) {
   const { token } = useRouteLoaderData("root");
   const canManage = isAdmin() || isModerator();
   const navigate = useNavigate();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
 
   const handleViewDetails = () => {
     navigate(`/events/${toSlug(event.title, event._id)}`);
@@ -20,17 +22,13 @@ export default function EventCard({ event }) {
   };
 
   const handleRemoveEvent = async () => {
-    const proceed = window.confirm(
-      "Are you sure you want to remove this event? This action cannot be undone."
-    );
-
-    if (!proceed) return;
-
+    setConfirmOpen(false);
+    setDeleteError(null);
     try {
       const response = await fetch(`${import.meta.env.VITE_DEV_URI}events/${event._id}`, {
         method: "DELETE",
         headers: {
-          Authorization: `Bearer ${token}`, // Pass the token for authentication
+          Authorization: `Bearer ${token}`,
         },
       });
 
@@ -39,11 +37,9 @@ export default function EventCard({ event }) {
         throw new Error(errorData.message || "Failed to delete the event.");
       }
 
-      alert("Event deleted successfully!");
-      window.location.reload(); // Reload the page to reflect changes
+      window.location.reload();
     } catch (error) {
-      console.error("Error deleting event:", error);
-      alert(error.message || "Failed to delete the event.");
+      setDeleteError(error.message || "Failed to delete the event.");
     }
   };
 
@@ -62,187 +58,204 @@ export default function EventCard({ event }) {
   };
 
   return (
-    <div className="glass-card w-full shadow-xl overflow-hidden rounded-xl border border-white/30 backdrop-blur-md hover:shadow-2xl transition-all duration-300 hover:scale-[1.02] flex flex-col h-full">
-      {/* Image */}
-      <div className="w-full">
-        {event.images && event.images.length > 0 ? (
-          <img
-            src={optimizeCloudinaryUrl(event.images[0])}
-            alt={event.title}
-            className="w-full h-48 object-cover"
-            width="400"
-            height="192"
-          />
-        ) : (
-          <div className="bg-gradient-to-br from-pink-100/60 to-purple-100/60 w-full h-48 flex items-center justify-center backdrop-blur-sm">
-            <svg
-              className="w-10 h-10 text-purple-300"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-          </div>
-        )}
-      </div>
+    <>
+      <ConfirmModal
+        isOpen={confirmOpen}
+        title="Delete Event?"
+        message={`Are you sure you want to remove "${event.title}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        onConfirm={handleRemoveEvent}
+        onCancel={() => setConfirmOpen(false)}
+      />
 
-      {/* Content */}
-      <div className="flex-1 flex flex-col p-5">
-        {/* Title — fixed height so cards align */}
-        <div className="flex items-start justify-between gap-2 min-h-[3rem]">
-          <h2 className="text-lg font-bold text-purple-700 line-clamp-2">{event.title}</h2>
-          {event.isReoccurring && (
-            <span className="flex-shrink-0 text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 font-medium border border-purple-200">
-              ↻ Recurring
-            </span>
+      <div className="glass-card w-full shadow-xl overflow-hidden rounded-xl border border-white/30 backdrop-blur-md hover:shadow-2xl transition-all duration-300 hover:scale-[1.02] flex flex-col h-full">
+        {/* Image */}
+        <div className="w-full">
+          {event.images && event.images.length > 0 ? (
+            <img
+              src={optimizeCloudinaryUrl(event.images[0])}
+              alt={event.title}
+              className="w-full h-48 object-cover"
+              width="400"
+              height="192"
+            />
+          ) : (
+            <div className="bg-gradient-to-br from-pink-100/60 to-purple-100/60 w-full h-48 flex items-center justify-center backdrop-blur-sm">
+              <svg
+                className="w-10 h-10 text-purple-300"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
           )}
         </div>
 
-        {/* Date and Location */}
-        <div className="flex flex-col mt-2 text-sm text-indigo-700 gap-1">
-          <div className="flex items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-4 w-4 mr-1.5 text-pink-500 flex-shrink-0"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
-            </svg>
-            <span className="truncate">{formatDateRange(event.date)}</span>
-          </div>
-          <div className="flex items-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-4 w-4 mr-1.5 text-pink-500 flex-shrink-0"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-            </svg>
-            <span className="truncate">
-              {event.city}
-              {event.street ? `: ${event.street}` : ""}
-            </span>
-          </div>
-        </div>
-
-        {/* Short Description — clamped to 2 lines */}
-        <p className="mt-3 text-sm text-purple-800 line-clamp-2">{event.shortDescription}</p>
-
-        {/* Tags */}
-        {renderTags() && <div className="mt-3">{renderTags()}</div>}
-
-        {/* Spacer pushes buttons to bottom */}
-        <div className="mt-auto pt-4">
-          {/* Featured badge — always takes space to keep cards aligned */}
-          <div className="mb-3 h-6">
-            {event.featured && (
-              <span className="inline-flex items-center text-xs px-2.5 py-1 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-medium">
-                ★ Featured
+        {/* Content */}
+        <div className="flex-1 flex flex-col p-5">
+          {/* Title */}
+          <div className="flex items-start justify-between gap-2 min-h-[3rem]">
+            <h2 className="text-lg font-bold text-purple-700 line-clamp-2">{event.title}</h2>
+            {event.isReoccurring && (
+              <span className="flex-shrink-0 text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 font-medium border border-purple-200">
+                ↻ Recurring
               </span>
             )}
           </div>
 
-          <button
-            onClick={handleViewDetails}
-            className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md w-full cursor-pointer"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5 mr-2"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
-            Event Details
-          </button>
-
-          {canManage && (
-            <div className="flex gap-2 mt-2">
-              <button
-                onClick={handleEditEvent}
-                className="btn btn-sm flex-1 glass border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
-                title="Edit Event"
+          {/* Date and Location */}
+          <div className="flex flex-col mt-2 text-sm text-indigo-700 gap-1">
+            <div className="flex items-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4 mr-1.5 text-pink-500 flex-shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                  />
-                </svg>
-                Edit
-              </button>
-              <button
-                onClick={handleRemoveEvent}
-                className="btn btn-sm flex-1 bg-red-100/50 border-red-300 text-red-700 hover:bg-red-200/50 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
-                title="Remove Event"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-                Remove
-              </button>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <span className="truncate">{formatDateRange(event.date)}</span>
             </div>
+            <div className="flex items-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4 mr-1.5 text-pink-500 flex-shrink-0"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              <span className="truncate">
+                {event.city}
+                {event.street ? `: ${event.street}` : ""}
+              </span>
+            </div>
+          </div>
+
+          {/* Short Description */}
+          <p className="mt-3 text-sm text-purple-800 line-clamp-2">{event.shortDescription}</p>
+
+          {/* Tags */}
+          {renderTags() && <div className="mt-3">{renderTags()}</div>}
+
+          {/* Delete error */}
+          {deleteError && (
+            <p className="mt-2 text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2">
+              {deleteError}
+            </p>
           )}
+
+          {/* Spacer pushes buttons to bottom */}
+          <div className="mt-auto pt-4">
+            <div className="mb-3 h-6">
+              {event.featured && (
+                <span className="inline-flex items-center text-xs px-2.5 py-1 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-medium">
+                  ★ Featured
+                </span>
+              )}
+            </div>
+
+            <button
+              onClick={handleViewDetails}
+              className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md w-full cursor-pointer"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-2"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                />
+              </svg>
+              Event Details
+            </button>
+
+            {canManage && (
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={handleEditEvent}
+                  className="btn btn-sm flex-1 glass border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
+                  title="Edit Event"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                    />
+                  </svg>
+                  Edit
+                </button>
+                <button
+                  onClick={() => setConfirmOpen(true)}
+                  className="btn btn-sm flex-1 bg-red-100/50 border-red-300 text-red-700 hover:bg-red-200/50 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
+                  title="Remove Event"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  Remove
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Form, useActionData, useNavigation, Navigate } from "react-router-dom";
+import { Form, useActionData, useNavigation, Navigate, Link } from "react-router-dom";
 import { isAuthenticated } from "../../auth/auth";
 import GoogleLogin from "../../components/auth/GoogleLogin";
 
@@ -119,6 +119,15 @@ const Login = () => {
         <div className="relative z-10">
           <p className="text-center text-gray-600 mt-4">or</p>
           <GoogleLogin />
+          <p className="text-center text-sm text-gray-500 mt-6">
+            Don&apos;t have an account?{" "}
+            <Link
+              to="/signup"
+              className="font-semibold text-pink-600 hover:text-purple-600 transition-colors"
+            >
+              Sign up
+            </Link>
+          </p>
         </div>
       </div>
     </div>

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Form, useActionData, useNavigation, Navigate } from "react-router-dom";
+import { Form, useActionData, useNavigation, Navigate, Link } from "react-router-dom";
 import GoogleLogin from "../../components/auth/GoogleLogin";
 import { isAuthenticated } from "../../auth/auth";
 
@@ -131,6 +131,15 @@ const Signup = () => {
         <div className="relative z-10">
           <p className="text-center text-gray-600 mt-4">or</p>
           <GoogleLogin />
+          <p className="text-center text-sm text-gray-500 mt-6">
+            Already have an account?{" "}
+            <Link
+              to="/login"
+              className="font-semibold text-pink-600 hover:text-purple-600 transition-colors"
+            >
+              Log in
+            </Link>
+          </p>
         </div>
       </div>
     </div>

--- a/src/pages/content/Home.jsx
+++ b/src/pages/content/Home.jsx
@@ -342,9 +342,37 @@ export default function Home() {
         </div>
       </div>
 
+      {/* ── Community Stats Strip ── */}
+      <div className="bg-gradient-to-r from-pink-500 via-purple-600 to-indigo-600 text-white py-8 px-4">
+        <div className="container mx-auto grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
+          {[
+            { value: "500+", label: "Community Members" },
+            { value: "50+", label: "Events Hosted" },
+            { value: "20+", label: "Courses Offered" },
+            { value: "Leeds", label: "Based in" },
+          ].map(({ value, label }) => (
+            <div key={label} className="flex flex-col items-center gap-1">
+              <span className="text-3xl font-bold tracking-tight">{value}</span>
+              <span className="text-sm text-purple-200 font-medium">{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
       {/* ── Upcoming Events ── */}
       <div className="container mx-auto p-6">
-        <h1 className="text-3xl font-bold text-center mb-8 text-purple-700">Upcoming Events</h1>
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-3xl font-bold text-purple-700">Upcoming Events</h2>
+          <Link
+            to="/events/asc"
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-pink-600 hover:text-purple-700 transition-colors"
+          >
+            View all
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        </div>
         {upcomingEvents?.length === 0 ? (
           <div className="glass-card p-8 text-center rounded-xl backdrop-blur-md shadow-xl">
             <p className="text-purple-600">No upcoming events found.</p>

--- a/src/pages/courses/Courses.jsx
+++ b/src/pages/courses/Courses.jsx
@@ -7,7 +7,6 @@ const CATEGORIES = ["All", "Language", "Religious", "Academic", "Arts", "Other"]
 
 export default function CoursesPage() {
   const { courses } = useRouteLoaderData("root");
-  console.log(courses);
   const canManage = isAdmin() || isModerator();
   const [activeCategory, setActiveCategory] = useState("All");
   const [search, setSearch] = useState("");


### PR DESCRIPTION
…, UX fixes

- Enrich Footer from one-liner to 4-column layout: brand, quick links, programmes, contact/location, bottom copyright bar
- Add "Don't have an account? Sign up" link to Login page
- Add "Already have an account? Log in" link to Signup page
- Add community stats strip (members, events, courses, location) to Home between hero and events grid; add "View all" link on events heading
- Replace window.confirm/alert in EventCard with ConfirmModal component; show inline error on delete failure instead of alert()
- Remove debug console.log from Courses page