### PR TITLE
feat: configurable billing interval UI and period end display

### DIFF
--- a/src/api/courseActions.js
+++ b/src/api/courseActions.js
@@ -1,6 +1,7 @@
 import { redirect } from "react-router-dom";
 import { getAuthToken } from "../auth/auth";
 import { compressImage } from "../util/compressImage";
+import { slugToId } from "../util/util";
 
 export async function courseAction({ request, params }) {
   const method = request.method.toUpperCase();
@@ -21,7 +22,9 @@ export async function courseAction({ request, params }) {
     city: formData.get("city"),
     postCode: formData.get("postCode"),
     enrollmentOpen: formData.get("enrollmentOpen") === "true",
-    isSubscription: formData.get("isSubscription") === "true",
+    isSubscription: formData.get("billingType") !== "one-time",
+    billingInterval:
+      formData.get("billingType") !== "one-time" ? formData.get("billingType") : "month",
     featured: formData.get("featured") === "true",
   };
 
@@ -34,8 +37,9 @@ export async function courseAction({ request, params }) {
     body.append("image", compressed);
   }
 
-  const url = params.courseId
-    ? `${import.meta.env.VITE_DEV_URI}courses/${params.courseId}`
+  const courseId = params.courseSlug ? slugToId(params.courseSlug) : null;
+  const url = courseId
+    ? `${import.meta.env.VITE_DEV_URI}courses/${courseId}`
     : `${import.meta.env.VITE_DEV_URI}courses`;
 
   try {

--- a/src/components/courses/CourseForm.jsx
+++ b/src/components/courses/CourseForm.jsx
@@ -153,12 +153,19 @@ const CourseForm = ({ method, course = {} }) => {
           <div className="form-control">
             <label className={labelClass}>Billing Type</label>
             <select
-              name="isSubscription"
+              name="billingType"
               className={selectClass}
-              defaultValue={course.isSubscription ? "true" : "false"}
+              defaultValue={
+                course.isSubscription
+                  ? course.billingInterval === "year"
+                    ? "year"
+                    : "month"
+                  : "one-time"
+              }
             >
-              <option value="false">One-time payment</option>
-              <option value="true">Monthly subscription (£/month)</option>
+              <option value="one-time">One-time payment</option>
+              <option value="month">Monthly subscription</option>
+              <option value="year">Yearly subscription</option>
             </select>
           </div>
 

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -16,6 +16,8 @@ function formatCurrency(amount) {
   return "£" + Number(amount ?? 0).toFixed(2);
 }
 
+const INTERVAL_ADJ = { month: "Monthly", year: "Yearly" };
+
 const TABS = ["Orders", "Teams", "Courses"];
 
 export default function ProfilePage() {
@@ -451,8 +453,9 @@ function EnrollmentRow({ enrollment }) {
   const handleCancel = () => {
     setConfirm({
       title: "Cancel subscription",
-      message:
-        "Are you sure you want to cancel? You'll keep access until the end of your current billing period.",
+      message: periodEnd
+        ? `Are you sure you want to cancel? You'll keep access until ${periodEnd.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}.`
+        : "Are you sure you want to cancel? You'll keep access until the end of your current billing period.",
       confirmText: "Yes, cancel",
       variant: "danger",
       onConfirm: async () => {
@@ -554,7 +557,7 @@ function EnrollmentRow({ enrollment }) {
             {enrollment._id.slice(-8).toUpperCase()}
             {" · "}
             {participants.length} participant{participants.length !== 1 ? "s" : ""}
-            {isSubscription && " · Monthly"}
+            {isSubscription && ` · ${INTERVAL_ADJ[course.billingInterval] || "Monthly"}`}
           </p>
         </div>
         <div className="flex flex-col items-end justify-center px-5 gap-2 flex-shrink-0">
@@ -615,7 +618,7 @@ function EnrollmentRow({ enrollment }) {
               </span>
             ) : (
               <span className="text-blue-600">
-                🔄 Monthly subscription
+                🔄 {INTERVAL_ADJ[course.billingInterval] || "Monthly"} subscription
                 {periodEnd && (
                   <span className="text-blue-400 ml-1">
                     · renews{" "}

--- a/src/pages/courses/CourseConfirmation.jsx
+++ b/src/pages/courses/CourseConfirmation.jsx
@@ -40,6 +40,12 @@ export default function CourseConfirmation() {
           <p className="text-purple-600 mt-2">
             {isFree ? "You've been enrolled for free." : "Payment received. You're now enrolled."}
           </p>
+          {!isLoading && course?.isSubscription && (
+            <p className="text-purple-500 text-sm mt-1">
+              Your {course.billingInterval === "year" ? "yearly" : "monthly"} subscription is now
+              active. Manage it anytime from your profile.
+            </p>
+          )}
         </div>
 
         {!isLoading && course && (

--- a/src/pages/courses/CourseDetails.jsx
+++ b/src/pages/courses/CourseDetails.jsx
@@ -6,6 +6,9 @@ import { getAuthToken, parseJwt, isAdmin, isModerator } from "../../auth/auth";
 import { Link } from "react-router-dom";
 import { slugToId } from "../../util/util";
 
+const INTERVAL_LABELS = { month: "month", year: "year" };
+const INTERVAL_ADJ = { month: "Monthly", year: "Yearly" };
+
 const CATEGORY_COLORS = {
   Language: "from-blue-500 to-indigo-600",
   Religious: "from-emerald-500 to-teal-600",
@@ -281,17 +284,20 @@ export default function CourseDetails() {
                 <h2 className="text-xl font-bold text-pink-700 mb-4">
                   {course.price > 0
                     ? course.isSubscription
-                      ? `Subscribe — £${course.price}/month`
+                      ? `Subscribe — £${course.price}/${INTERVAL_LABELS[course.billingInterval] || "month"}`
                       : `Enroll — £${course.price}`
                     : "Free Enrollment"}
                 </h2>
                 {course.isSubscription && (
                   <div className="bg-blue-50 border border-blue-200 rounded-xl p-3 mb-4 text-xs text-blue-700">
-                    <p className="font-semibold mb-1">📅 Monthly Subscription</p>
+                    <p className="font-semibold mb-1">
+                      📅 {INTERVAL_ADJ[course.billingInterval] || "Monthly"} Subscription
+                    </p>
                     <p>
-                      You'll be charged £{course.price} every month. You can cancel anytime from
-                      your profile, and you'll keep access until the end of your current billing
-                      period — no partial refunds.
+                      You'll be charged £{course.price} every{" "}
+                      {INTERVAL_LABELS[course.billingInterval] || "month"}. You can cancel anytime
+                      from your profile, and you'll keep access until the end of your current
+                      billing period — no partial refunds.
                     </p>
                   </div>
                 )}
@@ -464,7 +470,7 @@ export default function CourseDetails() {
                         </span>
                       ) : course.price > 0 ? (
                         course.isSubscription ? (
-                          `Subscribe £${course.price}/month`
+                          `Subscribe £${course.price}/${INTERVAL_LABELS[course.billingInterval] || "month"}`
                         ) : multiMode ? (
                           `Pay £${(course.price * participants.filter((p) => p.name.trim()).length).toFixed(2)} for ${participants.filter((p) => p.name.trim()).length} ${participants.filter((p) => p.name.trim()).length === 1 ? "person" : "people"}`
                         ) : (

--- a/src/pages/courses/CourseFormPage.jsx
+++ b/src/pages/courses/CourseFormPage.jsx
@@ -2,9 +2,11 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import CourseForm from "../../components/courses/CourseForm";
+import { slugToId } from "../../util/util";
 
 export default function CourseFormPage() {
-  const { courseId } = useParams();
+  const { courseSlug } = useParams();
+  const courseId = courseSlug ? slugToId(courseSlug) : null;
   const isEditing = !!courseId;
 
   const {


### PR DESCRIPTION
Add monthly/yearly billing options to CourseForm. Fix course edit form not loading data (slug vs ID mismatch in route params). Display dynamic interval labels across CourseDetails, ProfilePage, and confirmation. Show actual period end date in cancel dialog and subscription status bar.