### PR TITLE
refactor: unify events pages with card/calendar view toggle

### DIFF
--- a/__tests__/components/common/MainNavbar.test.jsx
+++ b/__tests__/components/common/MainNavbar.test.jsx
@@ -89,11 +89,14 @@ describe("MainNavbar", () => {
     parseJwt.mockReturnValue({ email: "alice@test.com" });
     getAuthToken.mockReturnValue("some-token");
 
+    // Profile dropdown uses onClick only on mobile (< 1024px)
+    Object.defineProperty(window, "innerWidth", { value: 500, writable: true });
     renderNavbar();
     await act(async () => {
       fireEvent.click(screen.getByText("alice@test.com"));
     });
     expect(screen.getByText("My Profile")).toBeInTheDocument();
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true });
   });
 
   it("should show Log out button when authenticated", async () => {
@@ -101,10 +104,12 @@ describe("MainNavbar", () => {
     parseJwt.mockReturnValue({ email: "alice@test.com" });
     getAuthToken.mockReturnValue("some-token");
 
+    Object.defineProperty(window, "innerWidth", { value: 500, writable: true });
     renderNavbar();
     await act(async () => {
       fireEvent.click(screen.getByText("alice@test.com"));
     });
     expect(screen.getByText("Log out")).toBeInTheDocument();
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true });
   });
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,6 @@ const Signup = lazy(() => import("./pages/auth/Signup"));
 const CancelPage = lazy(() => import("./pages/payments/CancelPage"));
 const TeamConfirmationPage = lazy(() => import("./pages/teams/TeamConfirmationPage"));
 const AdminDashboard = lazy(() => import("./pages/admin/AdminDashboard"));
-const SportsPage = lazy(() => import("./pages/content/Sports"));
 const ProfilePage = lazy(() => import("./pages/ProfilePage"));
 const TicketPage = lazy(() => import("./pages/tickets/TicketPage"));
 const TicketVerify = lazy(() => import("./pages/tickets/TicketVerify"));
@@ -75,8 +74,6 @@ const router = createBrowserRouter([
         element: w(EventRoot),
         children: [
           { index: true, element: w(EventPage) },
-          { path: "asc", element: w(EventPage) },
-          { path: "sports", element: w(SportsPage) },
           {
             path: ":eventSlug",
             id: "event-detail",

--- a/src/components/common/MainNavbar.jsx
+++ b/src/components/common/MainNavbar.jsx
@@ -6,10 +6,8 @@ import { isAuthenticated, isAdmin, parseJwt, getAuthToken, clearAuth } from "../
 export default function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
   const menuRef = useRef(null);
-  const dropdownRef = useRef(null);
   const userDropdownRef = useRef(null);
   const userCloseTimer = useRef(null);
   const location = useLocation();
@@ -27,15 +25,8 @@ export default function Navbar() {
     }
   })();
 
-  const toggleDropdown = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDropdownOpen(!dropdownOpen);
-  };
-
   const closeMenu = () => {
     setIsMenuOpen(false);
-    setDropdownOpen(false);
     setUserDropdownOpen(false);
   };
 
@@ -78,10 +69,6 @@ export default function Navbar() {
       const isMenuToggleButton = event.target.closest('button[aria-label="Toggle menu"]');
       if (menuRef.current && !menuRef.current.contains(event.target) && !isMenuToggleButton) {
         setIsMenuOpen(false);
-        setDropdownOpen(false);
-      }
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setDropdownOpen(false);
       }
       if (userDropdownRef.current && !userDropdownRef.current.contains(event.target)) {
         setUserDropdownOpen(false);
@@ -119,7 +106,6 @@ export default function Navbar() {
             if (isMenuOpen) {
               // If menu is open, explicitly close it
               setIsMenuOpen(false);
-              setDropdownOpen(false);
               setUserDropdownOpen(false);
             } else {
               // If menu is closed, open it
@@ -190,14 +176,15 @@ export default function Navbar() {
               <span className="hidden lg:block absolute bottom-0.5 left-1/2 transform -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-pink-500 to-purple-500 rounded-full group-hover:w-1/2 transition-all duration-300"></span>
             </Link>
           </li>
-          <li ref={dropdownRef} className="relative" tabIndex={0}>
-            <div
-              onClick={toggleDropdown}
-              className={`relative flex items-center px-3 py-2 lg:py-2 lg:px-4 xl:py-2.5 xl:px-5 text-sm lg:text-sm xl:text-base rounded-full cursor-pointer ${
+          <li>
+            <Link
+              to="/events"
+              className={`relative group flex items-center px-3 py-2 lg:py-2 lg:px-4 xl:py-2.5 xl:px-5 text-sm lg:text-sm xl:text-base rounded-full ${
                 location.pathname.includes("/events")
                   ? "bg-gradient-to-r from-rose-500/30 to-fuchsia-500/30 text-rose-700 font-semibold shadow-sm"
                   : "text-rose-600 hover:bg-rose-200/60 hover:shadow-sm"
               } transition-all duration-300`}
+              onClick={closeMenu}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -212,66 +199,11 @@ export default function Navbar() {
                 />
               </svg>
               Events
-              <svg
-                className={`ml-1 w-3.5 h-3.5 transition-transform duration-300 ${
-                  dropdownOpen ? "rotate-180" : ""
-                }`}
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.085l3.71-3.855a.75.75 0 1 1 1.08 1.04l-4.24 4.4a.75.75 0 0 1-1.08 0l-4.24-4.4a.75.75 0 0 1 .02-1.06z" />
-              </svg>
               {location.pathname.includes("/events") && (
                 <span className="hidden lg:block absolute bottom-0.5 left-1/2 transform -translate-x-1/2 w-1/2 h-0.5 bg-gradient-to-r from-rose-500 to-fuchsia-500 rounded-full"></span>
               )}
-            </div>
-            <ul
-              className={`absolute left-0 mt-2 w-56 bg-white/95 backdrop-blur-xl rounded-2xl shadow-2xl z-50 border border-white/30 overflow-hidden lg:left-1/2 lg:-translate-x-1/2 transition-all duration-300 ${
-                dropdownOpen
-                  ? "opacity-100 translate-y-0 pointer-events-auto"
-                  : "opacity-0 -translate-y-2 pointer-events-none"
-              }`}
-            >
-              <li>
-                <Link
-                  to="/events/asc"
-                  className="flex items-center px-5 py-3 hover:bg-gradient-to-r from-rose-100/60 to-pink-100/60 hover:shadow-inner text-rose-600 hover:text-rose-700 transition-all duration-300"
-                  onClick={closeMenu}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-4 w-4 mr-2"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z" />
-                  </svg>
-                  Ayendah Sazan Events
-                </Link>
-              </li>
-              <div className="h-px bg-gradient-to-r from-transparent via-purple-200 to-transparent"></div>
-              <li>
-                <Link
-                  to="/events/sports"
-                  className="flex items-center px-5 py-3 hover:bg-gradient-to-r from-fuchsia-100/60 to-purple-100/60 hover:shadow-inner text-fuchsia-600 hover:text-fuchsia-700 transition-all duration-300"
-                  onClick={closeMenu}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-4 w-4 mr-2"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  Sports Events
-                </Link>
-              </li>
-            </ul>
+              <span className="hidden lg:block absolute bottom-0.5 left-1/2 transform -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-rose-500 to-fuchsia-500 rounded-full group-hover:w-1/2 transition-all duration-300"></span>
+            </Link>
           </li>
           <li>
             <Link
@@ -425,7 +357,11 @@ export default function Navbar() {
               }}
             >
               <div
-                onClick={() => setUserDropdownOpen((prev) => !prev)}
+                onClick={() => {
+                  if (window.innerWidth < 1024) {
+                    setUserDropdownOpen((prev) => !prev);
+                  }
+                }}
                 className={`flex items-center gap-2 px-3 py-2 lg:py-2 lg:px-4 xl:py-2.5 xl:px-5 text-sm lg:text-sm xl:text-base rounded-full cursor-pointer transition-all duration-300 ${
                   userDropdownOpen
                     ? "bg-gradient-to-r from-indigo-500/30 to-purple-500/30 shadow-sm"

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,8 +1,13 @@
 import React, { useState } from "react";
-import { useNavigate, useRouteLoaderData } from "react-router-dom";
+import { Link, useNavigate, useRouteLoaderData } from "react-router-dom";
 import { isAdmin, isModerator } from "../../auth/auth";
 import { formatDateRange, optimizeCloudinaryUrl, toSlug } from "../../util/util";
 import ConfirmModal from "../common/ConfirmModal";
+
+const TYPE_COLORS = {
+  ASC: { bg: "from-pink-500 to-purple-600", badge: "bg-pink-100 text-pink-700" },
+  Sports: { bg: "from-emerald-500 to-teal-600", badge: "bg-emerald-100 text-emerald-700" },
+};
 
 export default function EventCard({ event }) {
   const { token } = useRouteLoaderData("root");
@@ -11,14 +16,11 @@ export default function EventCard({ event }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleteError, setDeleteError] = useState(null);
 
-  const handleViewDetails = () => {
-    navigate(`/events/${toSlug(event.title, event._id)}`);
-  };
+  const colors = TYPE_COLORS[event.typeOfEvent] || TYPE_COLORS.ASC;
+  const slug = toSlug(event.title, event._id);
 
   const handleEditEvent = () => {
-    navigate(`/events/${toSlug(event.title, event._id)}/edit`, {
-      state: { event },
-    });
+    navigate(`/events/${slug}/edit`, { state: { event } });
   };
 
   const handleRemoveEvent = async () => {
@@ -27,34 +29,16 @@ export default function EventCard({ event }) {
     try {
       const response = await fetch(`${import.meta.env.VITE_DEV_URI}events/${event._id}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
-
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.message || "Failed to delete the event.");
       }
-
       window.location.reload();
     } catch (error) {
       setDeleteError(error.message || "Failed to delete the event.");
     }
-  };
-
-  const renderTags = () => {
-    if (!event.categories || event.categories.length === 0) return null;
-
-    return (
-      <div className="flex flex-wrap gap-2">
-        {event.categories.map((category, index) => (
-          <span key={index} className="badge bg-purple-200/50 text-purple-700 border-purple-300">
-            {category}
-          </span>
-        ))}
-      </div>
-    );
   };
 
   return (
@@ -68,192 +52,173 @@ export default function EventCard({ event }) {
         onCancel={() => setConfirmOpen(false)}
       />
 
-      <div className="glass-card w-full shadow-xl overflow-hidden rounded-xl border border-white/30 backdrop-blur-md hover:shadow-2xl transition-all duration-300 hover:scale-[1.02] flex flex-col h-full">
-        {/* Image */}
-        <div className="w-full">
-          {event.images && event.images.length > 0 ? (
-            <img
-              src={optimizeCloudinaryUrl(event.images[0])}
-              alt={event.title}
-              className="w-full h-48 object-cover"
-              width="400"
-              height="192"
-            />
-          ) : (
-            <div className="bg-gradient-to-br from-pink-100/60 to-purple-100/60 w-full h-48 flex items-center justify-center backdrop-blur-sm">
-              <svg
-                className="w-10 h-10 text-purple-300"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+      <div className="group">
+        <div className="glass-card rounded-2xl shadow-lg border border-white/30 overflow-hidden hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col h-full">
+          <Link to={`/events/${slug}`} className="block">
+            {/* Image */}
+            {event.images && event.images.length > 0 ? (
+              <img
+                src={optimizeCloudinaryUrl(event.images[0])}
+                alt={event.title}
+                className="w-full h-44 object-cover"
+                width="400"
+                height="176"
+              />
+            ) : (
+              <div
+                className={`w-full h-44 bg-gradient-to-br ${colors.bg} flex items-center justify-center`}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                />
-              </svg>
-            </div>
-          )}
-        </div>
-
-        {/* Content */}
-        <div className="flex-1 flex flex-col p-5">
-          {/* Title */}
-          <div className="flex items-start justify-between gap-2 min-h-[3rem]">
-            <h2 className="text-lg font-bold text-purple-700 line-clamp-2">{event.title}</h2>
-            {event.isReoccurring && (
-              <span className="flex-shrink-0 text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 font-medium border border-purple-200">
-                ↻ Recurring
-              </span>
+                <svg
+                  className="w-14 h-14 text-white/60"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+              </div>
             )}
-          </div>
 
-          {/* Date and Location */}
-          <div className="flex flex-col mt-2 text-sm text-indigo-700 gap-1">
-            <div className="flex items-center">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-4 w-4 mr-1.5 text-pink-500 flex-shrink-0"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                />
-              </svg>
-              <span className="truncate">{formatDateRange(event.date)}</span>
+            <div className="p-5 flex-1 flex flex-col">
+              {/* Type badge + recurring badge */}
+              <div className="flex items-center justify-between mb-2">
+                <span
+                  className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${colors.badge}`}
+                >
+                  {event.typeOfEvent}
+                </span>
+                {event.isReoccurring && (
+                  <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-purple-100 text-purple-600 border border-purple-200">
+                    ↻ Recurring
+                  </span>
+                )}
+              </div>
+
+              {/* Title */}
+              <h3 className="text-lg font-bold text-purple-900 mb-1 group-hover:text-pink-600 transition-colors line-clamp-2">
+                {event.title}
+              </h3>
+
+              {/* Short description */}
+              <p className="text-sm text-purple-600 mb-3 line-clamp-2">{event.shortDescription}</p>
+
+              {/* Info rows */}
+              <div className="space-y-1.5 text-xs text-purple-600">
+                <div className="flex items-center gap-1.5">
+                  <svg
+                    className="w-3.5 h-3.5 flex-shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                  </svg>
+                  <span>{formatDateRange(event.date)}</span>
+                </div>
+                {event.city && (
+                  <div className="flex items-center gap-1.5">
+                    <svg
+                      className="w-3.5 h-3.5 flex-shrink-0"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                      />
+                    </svg>
+                    <span>
+                      {event.city}
+                      {event.street ? `: ${event.street}` : ""}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {/* Category tags */}
+              {event.categories && event.categories.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-3">
+                  {event.categories.map((category, index) => (
+                    <span
+                      key={index}
+                      className="text-xs px-2 py-0.5 rounded-full bg-purple-100 text-purple-700"
+                    >
+                      {category}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Featured badge — spacer always present to push buttons down */}
+              <div className="mt-auto pt-4 min-h-[2rem]">
+                {event.featured && (
+                  <span className="inline-flex items-center text-xs px-2.5 py-1 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-medium">
+                    ★ Featured
+                  </span>
+                )}
+              </div>
             </div>
-            <div className="flex items-center">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-4 w-4 mr-1.5 text-pink-500 flex-shrink-0"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
-              <span className="truncate">
-                {event.city}
-                {event.street ? `: ${event.street}` : ""}
-              </span>
-            </div>
-          </div>
-
-          {/* Short Description */}
-          <p className="mt-3 text-sm text-purple-800 line-clamp-2">{event.shortDescription}</p>
-
-          {/* Tags */}
-          {renderTags() && <div className="mt-3">{renderTags()}</div>}
+          </Link>
 
           {/* Delete error */}
           {deleteError && (
-            <p className="mt-2 text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2">
+            <p className="mx-5 mb-2 text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2">
               {deleteError}
             </p>
           )}
 
-          {/* Spacer pushes buttons to bottom */}
-          <div className="mt-auto pt-4">
-            <div className="mb-3 h-6">
-              {event.featured && (
-                <span className="inline-flex items-center text-xs px-2.5 py-1 rounded-full bg-gradient-to-r from-pink-500 to-purple-600 text-white font-medium">
-                  ★ Featured
-                </span>
-              )}
-            </div>
-
-            <button
-              onClick={handleViewDetails}
-              className="btn bg-gradient-to-r from-pink-500 to-purple-600 text-white border-none transition-all duration-300 shadow-md w-full cursor-pointer"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 mr-2"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+          {/* Admin/mod action bar */}
+          {canManage && (
+            <div className="flex gap-2 p-3 bg-gray-50/80 border-t border-gray-100 mt-auto">
+              <button
+                onClick={handleEditEvent}
+                className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg bg-purple-100 hover:bg-purple-200 text-purple-700 text-xs font-semibold transition-all cursor-pointer"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                />
-              </svg>
-              Event Details
-            </button>
-
-            {canManage && (
-              <div className="flex gap-2 mt-2">
-                <button
-                  onClick={handleEditEvent}
-                  className="btn btn-sm flex-1 glass border-purple-300 text-purple-700 hover:bg-purple-100/30 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
-                  title="Edit Event"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-4 w-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                    />
-                  </svg>
-                  Edit
-                </button>
-                <button
-                  onClick={() => setConfirmOpen(true)}
-                  className="btn btn-sm flex-1 bg-red-100/50 border-red-300 text-red-700 hover:bg-red-200/50 transition-all duration-300 flex items-center justify-center gap-1 cursor-pointer"
-                  title="Remove Event"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-4 w-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                    />
-                  </svg>
-                  Remove
-                </button>
-              </div>
-            )}
-          </div>
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+                Edit
+              </button>
+              <button
+                onClick={() => setConfirmOpen(true)}
+                className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg bg-red-100 hover:bg-red-200 text-red-600 text-xs font-semibold transition-all cursor-pointer"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+                Delete
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/src/pages/events/Event.jsx
+++ b/src/pages/events/Event.jsx
@@ -1,53 +1,183 @@
-import React from "react";
+import React, { useState } from "react";
 import { useRouteLoaderData } from "react-router-dom";
 import EventCard from "../../components/events/EventCard";
 import RecurringEventsCalendar from "../../components/events/RecurringEventsCalendar";
 
+const TYPE_TABS = [
+  { key: "all", label: "All Events" },
+  { key: "ASC", label: "ASC Events" },
+  { key: "Sports", label: "Sports Events" },
+];
+
 export default function EventPage() {
   const { events } = useRouteLoaderData("root");
-  // Only show events where typeOfEvent === 'ASC'
-  const ascEvents = events.filter((event) => event.typeOfEvent === "ASC");
+  const [view, setView] = useState("cards");
+  const [activeTab, setActiveTab] = useState("all");
+  const [search, setSearch] = useState("");
 
   const currentDate = new Date();
 
-  // Include recurring events in upcoming — they were previously hidden from listings
-  const upcomingEvents = ascEvents.filter(
+  // Type filtering
+  const typeFiltered =
+    activeTab === "all" ? events : events.filter((e) => e.typeOfEvent === activeTab);
+
+  // Search filtering (cards only)
+  const filtered = typeFiltered.filter((e) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      e.title?.toLowerCase().includes(q) ||
+      e.city?.toLowerCase().includes(q) ||
+      e.shortDescription?.toLowerCase().includes(q)
+    );
+  });
+
+  const upcomingEvents = filtered.filter(
     (event) => event.isReoccurring || new Date(event.date) >= currentDate
   );
-
-  // past events
-  const pastEvents = ascEvents.filter((event) => new Date(event.date) < currentDate);
+  const pastEvents = filtered.filter(
+    (event) => !event.isReoccurring && new Date(event.date) < currentDate
+  );
 
   return (
     <div className="bg-gradient-to-tr from-pink-100 via-purple-100 to-indigo-100 min-h-screen">
+      {/* Header */}
+      <div className="bg-gradient-to-r from-pink-500 to-purple-600 text-white p-8 md:p-14 shadow-lg">
+        <div className="container mx-auto text-center">
+          <h1 className="text-4xl md:text-5xl font-bold mb-3">Events</h1>
+          <p className="text-purple-100 text-lg">Discover upcoming events and activities</p>
+        </div>
+      </div>
+
       <div className="container mx-auto p-6">
-        <div className="glass-card rounded-2xl shadow-xl backdrop-blur-md mb-10 border border-white/30 p-6">
-          <RecurringEventsCalendar events={ascEvents} title="ASC Events Calendar" />
+        {/* View toggle + type tabs + search */}
+        <div className="flex flex-col sm:flex-row gap-3 mb-8">
+          {/* View toggle */}
+          <div className="flex bg-white/60 rounded-xl border border-white/40 p-1">
+            <button
+              onClick={() => setView("cards")}
+              className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer ${
+                view === "cards"
+                  ? "bg-gradient-to-r from-pink-500 to-purple-600 text-white shadow-md"
+                  : "text-purple-700 hover:bg-white/80"
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+                />
+              </svg>
+              Cards
+            </button>
+            <button
+              onClick={() => setView("calendar")}
+              className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer ${
+                view === "calendar"
+                  ? "bg-gradient-to-r from-pink-500 to-purple-600 text-white shadow-md"
+                  : "text-purple-700 hover:bg-white/80"
+              }`}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              Calendar
+            </button>
+          </div>
+
+          {/* Type filter tabs */}
+          <div className="flex gap-2 flex-wrap">
+            {TYPE_TABS.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={`px-3 py-2 rounded-xl text-sm font-medium transition-all cursor-pointer ${
+                  activeTab === tab.key
+                    ? "bg-gradient-to-r from-pink-500 to-purple-600 text-white shadow-md"
+                    : "bg-white/60 text-purple-700 hover:bg-white/80 border border-white/40"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Search (cards view only) */}
+          {view === "cards" && (
+            <div className="relative flex-1">
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-purple-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
+              <input
+                type="text"
+                placeholder="Search events..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="glass-input pl-9 py-2.5"
+              />
+            </div>
+          )}
         </div>
 
-        <h1 className="text-3xl font-bold text-center mb-6 text-purple-700">Upcoming Events</h1>
-        {upcomingEvents.length === 0 ? (
-          <div className="glass-card p-6 text-center rounded-xl">
-            <p className="text-purple-600">No events found.</p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {upcomingEvents.map((event) => (
-              <EventCard key={event._id} event={event} />
-            ))}
-          </div>
+        {/* Cards view */}
+        {view === "cards" && (
+          <>
+            <h2 className="text-2xl font-bold text-purple-800 mb-5">Upcoming Events</h2>
+            {upcomingEvents.length === 0 ? (
+              <div className="glass-card p-12 text-center rounded-2xl border border-white/30 mb-10">
+                <p className="text-purple-500 text-lg">No upcoming events found.</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+                {upcomingEvents.map((event) => (
+                  <EventCard key={event._id} event={event} />
+                ))}
+              </div>
+            )}
+
+            {pastEvents.length > 0 && (
+              <>
+                <h2 className="text-2xl font-bold text-indigo-700 mb-5">Past Events</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {pastEvents.map((event) => (
+                    <EventCard key={event._id} event={event} />
+                  ))}
+                </div>
+              </>
+            )}
+          </>
         )}
 
-        <h1 className="text-3xl font-bold text-center my-10 text-indigo-700">Past Events</h1>
-        {pastEvents.length === 0 ? (
-          <div className="glass-card p-6 text-center rounded-xl">
-            <p className="text-purple-600">No events found.</p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {pastEvents.map((event) => (
-              <EventCard key={event._id} event={event} />
-            ))}
+        {/* Calendar view */}
+        {view === "calendar" && (
+          <div className="glass-card rounded-2xl shadow-xl backdrop-blur-md border border-white/30 p-6">
+            <RecurringEventsCalendar
+              events={typeFiltered}
+              title={
+                activeTab === "all"
+                  ? "Events Calendar"
+                  : activeTab === "ASC"
+                    ? "ASC Events Calendar"
+                    : "Sports Events Calendar"
+              }
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
- Merge ASC Events and Sports Events into single Events page with type filter tabs
- Add Cards/Calendar view toggle (cards default, calendar alternative)
- Restyle EventCard to match CourseCard patterns (glass card, gradients, hover effects)
- Replace navbar Events dropdown with single Events link
- Profile dropdown: hover on desktop, click on mobile