### PR TITLE
Refactor admin dashboard: extract tab components, add pagination, fix…

### DIFF
--- a/src/components/admin/CoursesTab.jsx
+++ b/src/components/admin/CoursesTab.jsx
@@ -1,0 +1,283 @@
+import { useState } from "react";
+import SortableHeader from "../common/SortableHeader";
+import { formatDate, ENROLLMENT_STATUS, usePagination } from "./adminHelpers";
+import Pagination from "./Pagination";
+
+const ENROLL_STATUS_ORDER = {
+  active: 0,
+  paid: 1,
+  pending: 2,
+  free: 3,
+  past_due: 4,
+  cancelled: 5,
+};
+
+export default function CoursesTab({ enrollments, courses }) {
+  const [search, setSearch] = useState("");
+  const [view, setView] = useState("enrollments");
+  const [enrollSort, setEnrollSort] = useState({ key: null, dir: "asc" });
+  const [courseSort, setCourseSort] = useState({ key: null, dir: "asc" });
+
+  const filteredEnrollments = enrollments.filter(
+    (e) =>
+      e.buyerEmail?.toLowerCase().includes(search.toLowerCase()) ||
+      e.buyerPhone?.includes(search) ||
+      e.courseId?.title?.toLowerCase().includes(search.toLowerCase())
+  );
+  const filteredCourses = courses.filter(
+    (c) =>
+      c.title?.toLowerCase().includes(search.toLowerCase()) ||
+      c.instructor?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const sortedEnrollments = [...filteredEnrollments].sort((a, b) => {
+    if (!enrollSort.key) return 0;
+    let va, vb;
+    if (enrollSort.key === "status") {
+      va = ENROLL_STATUS_ORDER[a.status] ?? 6;
+      vb = ENROLL_STATUS_ORDER[b.status] ?? 6;
+    } else if (enrollSort.key === "date") {
+      va = new Date(a.createdAt);
+      vb = new Date(b.createdAt);
+    }
+    return enrollSort.dir === "asc" ? va - vb : vb - va;
+  });
+
+  const sortedCourses = [...filteredCourses].sort((a, b) => {
+    if (!courseSort.key) return 0;
+    if (courseSort.key === "category")
+      return courseSort.dir === "asc"
+        ? (a.category ?? "").localeCompare(b.category ?? "")
+        : (b.category ?? "").localeCompare(a.category ?? "");
+    let va, vb;
+    if (courseSort.key === "price") {
+      va = a.price ?? 0;
+      vb = b.price ?? 0;
+    } else if (courseSort.key === "enrolled") {
+      va = a.currentEnrollment ?? 0;
+      vb = b.currentEnrollment ?? 0;
+    } else if (courseSort.key === "status") {
+      va = a.enrollmentOpen ? 1 : 0;
+      vb = b.enrollmentOpen ? 1 : 0;
+    }
+    return courseSort.dir === "asc" ? va - vb : vb - va;
+  });
+
+  const enrollPg = usePagination(sortedEnrollments, [search, enrollSort.key, enrollSort.dir]);
+  const coursePg = usePagination(sortedCourses, [search, courseSort.key, courseSort.dir]);
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <input
+          type="text"
+          placeholder="Search courses or emails…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="glass-input flex-1"
+        />
+        <div className="flex bg-base-200 rounded-xl p-1 gap-1">
+          {["enrollments", "courses"].map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all capitalize cursor-pointer ${view === v ? "bg-white shadow-sm text-base-content" : "text-base-content/50 hover:text-base-content"}`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {view === "enrollments" && (
+        <>
+          <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
+            <table className="w-full text-sm min-w-[600px]">
+              <thead>
+                <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
+                  <th className="px-4 py-3 font-semibold text-base-content">Course</th>
+                  <th className="px-4 py-3 font-semibold text-base-content">Buyer Email</th>
+                  <th className="px-4 py-3 font-semibold text-base-content">Phone</th>
+                  <th className="px-4 py-3 font-semibold text-base-content">Participants</th>
+                  <SortableHeader
+                    label="Status"
+                    sortKey="status"
+                    sort={enrollSort}
+                    onSort={setEnrollSort}
+                  />
+                  <SortableHeader
+                    label="Date"
+                    sortKey="date"
+                    sort={enrollSort}
+                    onSort={setEnrollSort}
+                  />
+                  <th className="px-4 py-3 font-semibold text-base-content">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-base-100">
+                {enrollPg.paged.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="text-center py-10 text-base-content/50">
+                      No enrollments found
+                    </td>
+                  </tr>
+                ) : (
+                  enrollPg.paged.map((e) => (
+                    <tr key={e._id} className="bg-white hover:bg-base-200/30 transition-colors">
+                      <td className="px-4 py-3 font-medium text-base-content">
+                        {e.courseId?.title ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-base-content/70">{e.buyerEmail}</td>
+                      <td className="px-4 py-3 text-base-content/70">{e.buyerPhone || "—"}</td>
+                      <td className="px-4 py-3 text-base-content/70">
+                        {e.participants?.length > 0
+                          ? e.participants.map((p) => p.name).join(", ")
+                          : "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        {(() => {
+                          const st = ENROLLMENT_STATUS[e.status] ?? {
+                            label: e.status ?? "Unknown",
+                            classes: "bg-base-100 text-base-content/50 border-base-300",
+                          };
+                          return (
+                            <span
+                              className={`text-xs font-medium px-2 py-0.5 rounded-full border ${st.classes}`}
+                            >
+                              {st.label}
+                            </span>
+                          );
+                        })()}
+                      </td>
+                      <td className="px-4 py-3 text-base-content/50">{formatDate(e.createdAt)}</td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => {
+                            const participants = (e.participants || [])
+                              .map(
+                                (p) =>
+                                  `<tr><td style="padding:4px 12px;border-bottom:1px solid #eee">${p.name || "—"}</td><td style="padding:4px 12px;border-bottom:1px solid #eee">${p.email || "—"}</td></tr>`
+                              )
+                              .join("");
+                            const statusLabel = (
+                              ENROLLMENT_STATUS[e.status] ?? { label: e.status ?? "Unknown" }
+                            ).label;
+                            const w = window.open("", "_blank");
+                            w.document.write(
+                              `<html><head><title>Enrollment — ${e.courseId?.title || "Course"}</title><style>body{font-family:system-ui,sans-serif;max-width:600px;margin:40px auto;color:#1a1a1a}h1{font-size:20px;margin-bottom:4px}table{width:100%;border-collapse:collapse;margin-top:12px}th{text-align:left;padding:6px 12px;background:#f5f5f5;font-size:13px}td{font-size:13px}.meta{color:#666;font-size:13px;margin:2px 0}.badge{display:inline-block;padding:2px 10px;border-radius:12px;font-size:12px;font-weight:600}</style></head><body><h1>${e.courseId?.title || "Course"}</h1><p class="meta">Buyer: ${e.buyerEmail || "—"}</p><p class="meta">Phone: ${e.buyerPhone || "—"}</p><p class="meta">Status: <span class="badge" style="background:#f0f9ff;color:#0369a1">${statusLabel}</span></p><p class="meta">Date: ${formatDate(e.createdAt)}</p>${(e.participants?.length ?? 0) > 0 ? `<h2 style="font-size:16px;margin-top:20px">Participants</h2><table><thead><tr><th>Name</th><th>Email</th></tr></thead><tbody>${participants}</tbody></table>` : ""}<script>window.print()</script></body></html>`
+                            );
+                            w.document.close();
+                          }}
+                          className="p-1.5 rounded-lg hover:bg-base-200 text-base-content/50 hover:text-primary transition-colors cursor-pointer"
+                          title="Print enrollment"
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+                            />
+                          </svg>
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <Pagination
+            page={enrollPg.page}
+            totalPages={enrollPg.totalPages}
+            setPage={enrollPg.setPage}
+            total={filteredEnrollments.length}
+            label={`enrollment${filteredEnrollments.length !== 1 ? "s" : ""}`}
+          />
+        </>
+      )}
+
+      {view === "courses" && (
+        <>
+          <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
+            <table className="w-full text-sm min-w-[600px]">
+              <thead>
+                <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
+                  <th className="px-4 py-3 font-semibold text-base-content">Title</th>
+                  <th className="px-4 py-3 font-semibold text-base-content">Instructor</th>
+                  <SortableHeader
+                    label="Category"
+                    sortKey="category"
+                    sort={courseSort}
+                    onSort={setCourseSort}
+                  />
+                  <SortableHeader
+                    label="Price"
+                    sortKey="price"
+                    sort={courseSort}
+                    onSort={setCourseSort}
+                  />
+                  <SortableHeader
+                    label="Enrolled"
+                    sortKey="enrolled"
+                    sort={courseSort}
+                    onSort={setCourseSort}
+                  />
+                  <SortableHeader
+                    label="Status"
+                    sortKey="status"
+                    sort={courseSort}
+                    onSort={setCourseSort}
+                  />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-base-100">
+                {coursePg.paged.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="text-center py-10 text-base-content/50">
+                      No courses found
+                    </td>
+                  </tr>
+                ) : (
+                  coursePg.paged.map((c) => (
+                    <tr key={c._id} className="bg-white hover:bg-base-200/30 transition-colors">
+                      <td className="px-4 py-3 font-medium text-base-content">{c.title}</td>
+                      <td className="px-4 py-3 text-base-content/70">{c.instructor}</td>
+                      <td className="px-4 py-3 text-base-content/70">{c.category}</td>
+                      <td className="px-4 py-3 text-base-content/70">
+                        {c.price > 0 ? `£${c.price}` : "Free"}
+                      </td>
+                      <td className="px-4 py-3 text-base-content/70">
+                        {c.currentEnrollment}
+                        {c.maxEnrollment ? ` / ${c.maxEnrollment}` : ""}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`text-xs font-medium px-2 py-0.5 rounded-full border ${c.enrollmentOpen ? "bg-green-50 text-green-700 border-green-200" : "bg-base-100 text-base-content/50 border-base-300"}`}
+                        >
+                          {c.enrollmentOpen ? "Open" : "Closed"}
+                        </span>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <Pagination
+            page={coursePg.page}
+            totalPages={coursePg.totalPages}
+            setPage={coursePg.setPage}
+            total={filteredCourses.length}
+            label={`course${filteredCourses.length !== 1 ? "s" : ""}`}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/Pagination.jsx
+++ b/src/components/admin/Pagination.jsx
@@ -1,0 +1,60 @@
+export default function Pagination({ page, totalPages, setPage, total, label }) {
+  if (totalPages <= 1) {
+    return (
+      <p className="text-xs text-base-content/50 mt-3">
+        {total} {label}
+      </p>
+    );
+  }
+  const range = [];
+  let start = Math.max(1, page - 2);
+  let end = Math.min(totalPages, start + 4);
+  start = Math.max(1, end - 4);
+  for (let i = start; i <= end; i++) range.push(i);
+
+  return (
+    <div className="flex items-center justify-between mt-3 gap-2 flex-wrap">
+      <p className="text-xs text-base-content/50">
+        {total} {label}
+      </p>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => setPage(page - 1)}
+          disabled={page <= 1}
+          className="px-2 py-1 rounded-lg text-xs font-medium text-base-content/50 hover:text-base-content hover:bg-base-200 disabled:opacity-30 disabled:pointer-events-none transition-colors cursor-pointer"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+        {range.map((n) => (
+          <button
+            key={n}
+            onClick={() => setPage(n)}
+            className={`min-w-[28px] px-1.5 py-1 rounded-lg text-xs font-medium transition-colors cursor-pointer ${
+              n === page
+                ? "bg-primary text-white shadow-sm"
+                : "text-base-content/50 hover:text-base-content hover:bg-base-200"
+            }`}
+          >
+            {n}
+          </button>
+        ))}
+        <button
+          onClick={() => setPage(page + 1)}
+          disabled={page >= totalPages}
+          className="px-2 py-1 rounded-lg text-xs font-medium text-base-content/50 hover:text-base-content hover:bg-base-200 disabled:opacity-30 disabled:pointer-events-none transition-colors cursor-pointer"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/RevenueTab.jsx
+++ b/src/components/admin/RevenueTab.jsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { Bar } from "react-chartjs-2";
+import SortableHeader from "../common/SortableHeader";
+
+export default function RevenueTab({ events }) {
+  const [sort, setSort] = useState({ key: null, dir: "asc" });
+
+  const chartData = {
+    labels: events.map((e) => e.title),
+    datasets: [
+      {
+        label: "Revenue (£)",
+        data: events.map((e) => e.totalRevenue ?? 0),
+        backgroundColor: "rgba(59, 130, 172, 0.6)",
+        borderColor: "rgba(59, 130, 172, 1)",
+        borderWidth: 1,
+        borderRadius: 6,
+      },
+    ],
+  };
+
+  const totalRevenue = events.reduce((sum, e) => sum + (e.totalRevenue ?? 0), 0);
+
+  const sorted = [...events].sort((a, b) => {
+    if (!sort.key) return 0;
+    let va, vb;
+    if (sort.key === "event")
+      return sort.dir === "asc"
+        ? (a.title ?? "").localeCompare(b.title ?? "")
+        : (b.title ?? "").localeCompare(a.title ?? "");
+    if (sort.key === "revenue") {
+      va = a.totalRevenue ?? 0;
+      vb = b.totalRevenue ?? 0;
+    } else if (sort.key === "tickets") {
+      va = a.ticketsAvailable ?? 0;
+      vb = b.ticketsAvailable ?? 0;
+    } else if (sort.key === "price") {
+      va = a.ticketPrice ?? 0;
+      vb = b.ticketPrice ?? 0;
+    }
+    return sort.dir === "asc" ? va - vb : vb - va;
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
+          <p className="text-xs text-base-content/50 mb-1">Total Revenue</p>
+          <p className="text-2xl font-bold text-base-content">£{totalRevenue.toFixed(2)}</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
+          <p className="text-xs text-base-content/50 mb-1">Events with Sales</p>
+          <p className="text-2xl font-bold text-base-content">
+            {events.filter((e) => (e.totalRevenue ?? 0) > 0).length}
+          </p>
+        </div>
+        <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
+          <p className="text-xs text-base-content/50 mb-1">Total Events</p>
+          <p className="text-2xl font-bold text-base-content">{events.length}</p>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
+        <div className="h-72">
+          <Bar
+            data={chartData}
+            options={{
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: { legend: { display: false } },
+              scales: { y: { beginAtZero: true, ticks: { callback: (v) => "£" + v } } },
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
+        <table className="w-full text-sm min-w-[600px]">
+          <thead>
+            <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
+              <SortableHeader label="Event" sortKey="event" sort={sort} onSort={setSort} />
+              <SortableHeader label="Revenue" sortKey="revenue" sort={sort} onSort={setSort} />
+              <SortableHeader label="Tickets Left" sortKey="tickets" sort={sort} onSort={setSort} />
+              <SortableHeader label="Price/ticket" sortKey="price" sort={sort} onSort={setSort} />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-base-100">
+            {sorted.map((e) => (
+              <tr key={e._id} className="bg-white hover:bg-base-200/30 transition-colors">
+                <td className="px-4 py-3 font-medium text-base-content">{e.title}</td>
+                <td className="px-4 py-3 text-green-700 font-medium">
+                  £{(e.totalRevenue ?? 0).toFixed(2)}
+                </td>
+                <td className="px-4 py-3 text-base-content/70">{e.ticketsAvailable ?? "—"}</td>
+                <td className="px-4 py-3 text-base-content/70">
+                  £{(e.ticketPrice ?? 0).toFixed(2)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/TeamsTab.jsx
+++ b/src/components/admin/TeamsTab.jsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { formatDate, usePagination } from "./adminHelpers";
+import Pagination from "./Pagination";
+
+const TEAM_SORT_OPTIONS = [
+  { key: "members", label: "Members" },
+  { key: "paid", label: "Payment" },
+];
+
+export default function TeamsTab({ teams }) {
+  const [expanded, setExpanded] = useState(null);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState({ key: null, dir: "asc" });
+
+  const handleTeamSort = (key) => {
+    if (sort.key === key) {
+      setSort({ key, dir: sort.dir === "asc" ? "desc" : "asc" });
+    } else {
+      setSort({ key, dir: "asc" });
+    }
+  };
+
+  const filtered = teams.filter((t) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      t.name?.toLowerCase().includes(q) ||
+      t.manager?.name?.toLowerCase().includes(q) ||
+      t.manager?.email?.toLowerCase().includes(q) ||
+      t.manager?.phone?.includes(q) ||
+      t.members?.some(
+        (m) => m.name?.toLowerCase().includes(q) || m.email?.toLowerCase().includes(q)
+      )
+    );
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (!sort.key) return 0;
+    let va, vb;
+    if (sort.key === "members") {
+      va = a.members?.length ?? 0;
+      vb = b.members?.length ?? 0;
+    } else if (sort.key === "paid") {
+      va = a.paid ? 1 : 0;
+      vb = b.paid ? 1 : 0;
+    }
+    return sort.dir === "asc" ? va - vb : vb - va;
+  });
+
+  const pg = usePagination(sorted, [search, sort.key, sort.dir]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 mb-1">
+        <input
+          type="text"
+          placeholder="Search teams, members, or email…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="glass-input flex-1 max-w-xs"
+        />
+        <div className="flex bg-base-200 rounded-xl p-1 gap-1">
+          {TEAM_SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.key}
+              onClick={() => handleTeamSort(opt.key)}
+              className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all cursor-pointer ${
+                sort.key === opt.key
+                  ? "bg-gradient-to-r from-primary to-primary/70 text-white shadow-sm"
+                  : "text-base-content/50 hover:text-base-content"
+              }`}
+            >
+              {opt.label}
+              {sort.key === opt.key && (
+                <svg
+                  className={`w-3 h-3 transition-transform ${sort.dir === "desc" ? "rotate-180" : ""}`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 15l7-7 7 7"
+                  />
+                </svg>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+      {pg.paged.length === 0 && (
+        <p className="text-center text-base-content/50 py-12">No team registrations found</p>
+      )}
+      {pg.paged.map((team) => (
+        <div
+          key={team._id}
+          className="bg-white rounded-2xl border border-base-300 shadow-sm overflow-hidden"
+        >
+          <div className="px-5 py-4 flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <p className="font-semibold text-base-content">{team.name}</p>
+              <p className="text-xs text-base-content/50 mt-0.5">
+                {team.event?.title ?? "Unknown event"}
+                {team.event?.date && <span> · {formatDate(team.event.date)}</span>}
+              </p>
+              <p className="text-xs text-base-content/50 mt-0.5">
+                Manager: {team.manager?.name} · {team.manager?.email}
+                {team.manager?.phone && ` · ${team.manager.phone}`}
+              </p>
+            </div>
+            <div className="flex items-start gap-2">
+              <div className="flex flex-col items-end gap-1">
+                <span
+                  className={
+                    "text-xs font-medium px-2 py-0.5 rounded-full border " +
+                    (team.paid
+                      ? "bg-green-50 text-green-700 border-green-200"
+                      : "bg-orange-50 text-orange-600 border-orange-200")
+                  }
+                >
+                  {team.paid ? "✓ Paid" : "Pending"}
+                </span>
+                <span className="text-xs text-base-content/50">
+                  {team.members?.length ?? 0} members
+                </span>
+              </div>
+              <button
+                onClick={() => {
+                  const members = (team.members || [])
+                    .map(
+                      (m) =>
+                        `<tr><td style="padding:4px 12px;border-bottom:1px solid #eee">${m.name || "—"}</td><td style="padding:4px 12px;border-bottom:1px solid #eee">${m.email || "—"}</td></tr>`
+                    )
+                    .join("");
+                  const w = window.open("", "_blank");
+                  w.document.write(
+                    `<html><head><title>Team — ${team.name}</title><style>body{font-family:system-ui,sans-serif;max-width:600px;margin:40px auto;color:#1a1a1a}h1{font-size:20px;margin-bottom:4px}table{width:100%;border-collapse:collapse;margin-top:12px}th{text-align:left;padding:6px 12px;background:#f5f5f5;font-size:13px}td{font-size:13px}.meta{color:#666;font-size:13px;margin:2px 0}.badge{display:inline-block;padding:2px 10px;border-radius:12px;font-size:12px;font-weight:600}</style></head><body><h1>${team.name}</h1><p class="meta">${team.event?.title || "Unknown event"}${team.event?.date ? " · " + formatDate(team.event.date) : ""}</p><p class="meta">Manager: ${team.manager?.name || "—"} · ${team.manager?.email || "—"}${team.manager?.phone ? " · " + team.manager.phone : ""}</p><p class="meta">Status: <span class="badge" style="background:${team.paid ? "#dcfce7;color:#15803d" : "#fff7ed;color:#ea580c"}">${team.paid ? "Paid" : "Pending"}</span></p>${(team.members?.length ?? 0) > 0 ? `<table><thead><tr><th>Name</th><th>Email</th></tr></thead><tbody>${members}</tbody></table>` : ""}<script>window.print()</script></body></html>`
+                  );
+                  w.document.close();
+                }}
+                className="p-1.5 rounded-lg hover:bg-base-200 text-base-content/50 hover:text-primary transition-colors cursor-pointer shrink-0"
+                title="Print team details"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          {team.members?.length > 0 && (
+            <div className="px-5 pb-4">
+              <button
+                onClick={() => setExpanded(expanded === team._id ? null : team._id)}
+                className="text-xs text-base-content/70 hover:text-base-content font-medium flex items-center gap-1 cursor-pointer"
+              >
+                {expanded === team._id ? "Hide members" : "Show members"}
+                <svg
+                  className={
+                    "w-3 h-3 transition-transform " + (expanded === team._id ? "rotate-180" : "")
+                  }
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </button>
+              {expanded === team._id && (
+                <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+                  {team.members.map((m, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center gap-2 text-xs text-base-content/70 bg-base-200/50 rounded-lg px-3 py-1.5"
+                    >
+                      <span className="w-5 h-5 rounded-full bg-base-200 text-base-content/70 font-bold flex items-center justify-center text-[10px]">
+                        {m.name?.[0]?.toUpperCase() ?? "?"}
+                      </span>
+                      <span>{m.name}</span>
+                      {m.email && <span className="text-base-content/50">· {m.email}</span>}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+      <Pagination
+        page={pg.page}
+        totalPages={pg.totalPages}
+        setPage={pg.setPage}
+        total={filtered.length}
+        label={`team${filtered.length !== 1 ? "s" : ""}`}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/TicketsTab.jsx
+++ b/src/components/admin/TicketsTab.jsx
@@ -1,0 +1,236 @@
+import React, { useState } from "react";
+import SortableHeader from "../common/SortableHeader";
+import { formatDate, usePagination } from "./adminHelpers";
+import Pagination from "./Pagination";
+
+function groupByPayment(tickets) {
+  const map = new Map();
+  for (const t of tickets) {
+    const key = t.paymentId || t._id;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(t);
+  }
+  return Array.from(map.values());
+}
+
+export default function TicketsTab({ tickets }) {
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState({ key: null, dir: "asc" });
+  const [expanded, setExpanded] = useState(null);
+
+  const groups = groupByPayment(tickets);
+
+  const filtered = groups.filter((g) => {
+    const q = search.toLowerCase();
+    return g.some(
+      (t) =>
+        t.buyerEmail?.toLowerCase().includes(q) ||
+        t.eventId?.title?.toLowerCase().includes(q) ||
+        t.ticketCode?.toLowerCase().includes(q)
+    );
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (!sort.key) return 0;
+    const fa = a[0],
+      fb = b[0];
+    let va, vb;
+    if (sort.key === "date") {
+      va = new Date(fa.createdAt);
+      vb = new Date(fb.createdAt);
+    } else if (sort.key === "paid") {
+      va = (fa.eventId?.ticketPrice ?? 0) * a.length;
+      vb = (fb.eventId?.ticketPrice ?? 0) * b.length;
+    } else if (sort.key === "quantity") {
+      va = a.length;
+      vb = b.length;
+    }
+    return sort.dir === "asc" ? va - vb : vb - va;
+  });
+
+  const totalTickets = filtered.reduce((sum, g) => sum + g.length, 0);
+  const pg = usePagination(sorted, [search, sort.key, sort.dir]);
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Search by buyer email, event, or ticket code…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="glass-input mb-4"
+      />
+      <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
+        <table className="w-full text-sm min-w-[600px]">
+          <thead>
+            <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
+              <th className="px-4 py-3 w-8" />
+              <th className="px-4 py-3 font-semibold text-base-content">Event</th>
+              <th className="px-4 py-3 font-semibold text-base-content">Buyer Email</th>
+              <SortableHeader label="Qty" sortKey="quantity" sort={sort} onSort={setSort} />
+              <SortableHeader label="Paid" sortKey="paid" sort={sort} onSort={setSort} />
+              <SortableHeader label="Date" sortKey="date" sort={sort} onSort={setSort} />
+              <th className="px-4 py-3 font-semibold text-base-content">Ref</th>
+              <th className="px-4 py-3 font-semibold text-base-content">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-base-100">
+            {pg.paged.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="text-center py-10 text-base-content/50">
+                  No tickets found
+                </td>
+              </tr>
+            ) : (
+              pg.paged.map((group) => {
+                const first = group[0];
+                const key = first.paymentId || first._id;
+                const isMulti = group.length > 1;
+                const isExpanded = expanded === key;
+                return (
+                  <React.Fragment key={key}>
+                    <tr
+                      className="bg-white hover:bg-base-200/30 transition-colors cursor-pointer"
+                      onClick={() => {
+                        if (isMulti) setExpanded(isExpanded ? null : key);
+                        else if (first.ticketCode)
+                          window.open(`/tickets/${first.ticketCode}`, "_blank");
+                      }}
+                    >
+                      <td className="px-4 py-3">
+                        {isMulti && (
+                          <svg
+                            className={`w-4 h-4 text-base-content/40 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M9 5l7 7-7 7"
+                            />
+                          </svg>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 font-medium text-base-content">
+                        {first.eventId?.title ?? "—"}
+                      </td>
+                      <td className="px-4 py-3 text-base-content/70">{first.buyerEmail}</td>
+                      <td className="px-4 py-3 text-base-content/70">
+                        {group.length}
+                        {isMulti && (
+                          <span className="text-[10px] text-base-content/40 ml-1">tickets</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-green-700 font-medium">
+                        £{((first.eventId?.ticketPrice ?? 0) * group.length).toFixed(2)}
+                      </td>
+                      <td className="px-4 py-3 text-base-content/50">
+                        {formatDate(first.createdAt)}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-[11px] text-base-content/40">
+                        {first.paymentId ? "…" + first.paymentId.slice(-8) : "—"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-1">
+                          {!isMulti && first.ticketCode && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                window.open(`/tickets/${first.ticketCode}?print=true`, "_blank");
+                              }}
+                              className="p-1.5 rounded-lg hover:bg-base-200 text-base-content/50 hover:text-primary transition-colors cursor-pointer"
+                              title="Print ticket"
+                            >
+                              <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+                                />
+                              </svg>
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                    {isMulti &&
+                      isExpanded &&
+                      group.map((t) => (
+                        <tr
+                          key={t._id}
+                          className="bg-base-100/50 hover:bg-base-200/40 transition-colors cursor-pointer"
+                          onClick={() =>
+                            t.ticketCode && window.open(`/tickets/${t.ticketCode}`, "_blank")
+                          }
+                        >
+                          <td className="px-4 py-2" />
+                          <td className="px-4 py-2 text-base-content/50 text-xs pl-8">
+                            <span className="font-mono">{t.ticketCode ?? "—"}</span>
+                          </td>
+                          <td className="px-4 py-2 text-base-content/50 text-xs">{t.buyerEmail}</td>
+                          <td className="px-4 py-2 text-base-content/50 text-xs">1</td>
+                          <td className="px-4 py-2 text-green-700/70 text-xs font-medium">
+                            £{(first.eventId?.ticketPrice ?? 0).toFixed(2)}
+                          </td>
+                          <td className="px-4 py-2 text-base-content/40 text-xs">
+                            {t.checkedIn ? (
+                              <span className="text-green-600 font-medium">Checked in</span>
+                            ) : (
+                              "Not checked in"
+                            )}
+                          </td>
+                          <td className="px-4 py-2" />
+                          <td className="px-4 py-2">
+                            {t.ticketCode && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  window.open(`/tickets/${t.ticketCode}?print=true`, "_blank");
+                                }}
+                                className="p-1 rounded-lg hover:bg-base-200 text-base-content/50 hover:text-primary transition-colors cursor-pointer"
+                                title="Print ticket"
+                              >
+                                <svg
+                                  className="w-3.5 h-3.5"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+                                  />
+                                </svg>
+                              </button>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                  </React.Fragment>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+      <Pagination
+        page={pg.page}
+        totalPages={pg.totalPages}
+        setPage={pg.setPage}
+        total={totalTickets}
+        label={`ticket${totalTickets !== 1 ? "s" : ""} · ${sorted.length} order${sorted.length !== 1 ? "s" : ""}`}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/UsersTab.jsx
+++ b/src/components/admin/UsersTab.jsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { getAuthToken } from "../../auth/auth";
+import SortableHeader from "../common/SortableHeader";
+import { formatDate, roleBadgeClass, usePagination } from "./adminHelpers";
+import Pagination from "./Pagination";
+
+const ROLE_ORDER = { admin: 0, moderator: 1, user: 2 };
+
+export default function UsersTab({ users, currentUserId, onRoleChange }) {
+  const [updating, setUpdating] = useState(null);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState({ key: null, dir: "asc" });
+
+  const filtered = users.filter(
+    (u) =>
+      u.name?.toLowerCase().includes(search.toLowerCase()) ||
+      u.email?.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (!sort.key) return 0;
+    let va, vb;
+    if (sort.key === "role") {
+      va = ROLE_ORDER[a.role] ?? 3;
+      vb = ROLE_ORDER[b.role] ?? 3;
+    } else if (sort.key === "joined") {
+      va = new Date(a.createdAt);
+      vb = new Date(b.createdAt);
+    }
+    return sort.dir === "asc" ? va - vb : vb - va;
+  });
+
+  const pg = usePagination(sorted, [search, sort.key, sort.dir]);
+
+  const handleRole = async (userId, newRole) => {
+    setUpdating(userId);
+    const token = getAuthToken();
+    try {
+      const res = await fetch(`${import.meta.env.VITE_DEV_URI}admin/users/${userId}/role`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer " + token,
+        },
+        body: JSON.stringify({ role: newRole }),
+      });
+      const data = await res.json();
+      if (res.ok) onRoleChange(userId, newRole);
+      else alert(data.message);
+    } catch {
+      alert("Failed to update role");
+    } finally {
+      setUpdating(null);
+    }
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Search by name or email…"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="glass-input mb-4"
+      />
+      <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
+        <table className="w-full text-sm min-w-[600px]">
+          <thead>
+            <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
+              <th className="px-4 py-3 font-semibold text-base-content">Name</th>
+              <th className="px-4 py-3 font-semibold text-base-content">Email</th>
+              <SortableHeader label="Role" sortKey="role" sort={sort} onSort={setSort} />
+              <SortableHeader label="Joined" sortKey="joined" sort={sort} onSort={setSort} />
+              <th className="px-4 py-3 font-semibold text-base-content">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-base-100">
+            {pg.paged.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="text-center py-10 text-base-content/50">
+                  No users found
+                </td>
+              </tr>
+            ) : (
+              pg.paged.map((u) => (
+                <tr key={u._id} className="bg-white hover:bg-base-200/30 transition-colors">
+                  <td className="px-4 py-3 font-medium text-base-content">{u.name}</td>
+                  <td className="px-4 py-3 text-base-content/70">{u.email}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={
+                        "text-xs font-medium px-2 py-0.5 rounded-full border capitalize " +
+                        (roleBadgeClass[u.role] ?? roleBadgeClass.user)
+                      }
+                    >
+                      {u.role}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-base-content/50">{formatDate(u.createdAt)}</td>
+                  <td className="px-4 py-3">
+                    {u._id === currentUserId ? (
+                      <span className="text-xs text-base-content/50 italic">you</span>
+                    ) : (
+                      <select
+                        value={u.role}
+                        disabled={updating === u._id}
+                        onChange={(e) => handleRole(u._id, e.target.value)}
+                        className="glass-input glass-select text-xs px-2 py-1 disabled:opacity-50"
+                      >
+                        <option value="user">user</option>
+                        <option value="moderator">moderator</option>
+                        <option value="admin">admin</option>
+                      </select>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      <Pagination
+        page={pg.page}
+        totalPages={pg.totalPages}
+        setPage={pg.setPage}
+        total={filtered.length}
+        label={`user${filtered.length !== 1 ? "s" : ""}`}
+      />
+    </div>
+  );
+}

--- a/src/components/admin/adminHelpers.js
+++ b/src/components/admin/adminHelpers.js
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+
+export const PAGE_SIZE = 15;
+
+export function formatDate(d) {
+  if (!d) return "—";
+  return new Date(d).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export const ENROLLMENT_STATUS = {
+  pending: { label: "Pending", classes: "bg-yellow-50 text-yellow-700 border-yellow-200" },
+  paid: { label: "Paid", classes: "bg-green-50 text-green-700 border-green-200" },
+  free: { label: "Free", classes: "bg-blue-50 text-blue-600 border-blue-200" },
+  active: { label: "Active", classes: "bg-emerald-50 text-emerald-700 border-emerald-200" },
+  cancelled: { label: "Cancelled", classes: "bg-red-50 text-red-600 border-red-200" },
+  past_due: { label: "Past Due", classes: "bg-orange-50 text-orange-600 border-orange-200" },
+};
+
+export const roleBadgeClass = {
+  admin: "bg-yellow-100 text-yellow-800 border-yellow-300",
+  moderator: "bg-blue-100 text-blue-700 border-blue-200",
+  user: "bg-base-200 text-base-content/70 border-base-300",
+};
+
+export function usePagination(items, deps) {
+  const [page, setPage] = useState(1);
+
+  // Reset to page 1 when dependencies (search/sort/filter) change
+  useEffect(() => {
+    setPage(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  const totalPages = Math.max(1, Math.ceil(items.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const paged = items.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+  return { page: safePage, totalPages, setPage, paged, total: items.length };
+}

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -1,7 +1,5 @@
-import React from "react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Bar } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -14,757 +12,20 @@ import {
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
 import { getAuthToken, getUserRole as getAuthRole } from "../../auth/auth";
-import SortableHeader from "../../components/common/SortableHeader";
 import { PageContainer, Spinner } from "../../components/ui";
+import { roleBadgeClass } from "../../components/admin/adminHelpers";
+import TicketsTab from "../../components/admin/TicketsTab";
+import RevenueTab from "../../components/admin/RevenueTab";
+import TeamsTab from "../../components/admin/TeamsTab";
+import CoursesTab from "../../components/admin/CoursesTab";
+import UsersTab from "../../components/admin/UsersTab";
 
 function getRole() {
   return getAuthRole();
 }
 
-function formatDate(d) {
-  if (!d) return "—";
-  return new Date(d).toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
-}
-
 const TABS = ["Tickets", "Revenue", "Teams", "Courses", "Users"];
-
-const ENROLLMENT_STATUS = {
-  pending: { label: "Pending", classes: "bg-yellow-50 text-yellow-700 border-yellow-200" },
-  paid: { label: "Paid", classes: "bg-green-50 text-green-700 border-green-200" },
-  free: { label: "Free", classes: "bg-blue-50 text-blue-600 border-blue-200" },
-  active: { label: "Active", classes: "bg-emerald-50 text-emerald-700 border-emerald-200" },
-  cancelled: { label: "Cancelled", classes: "bg-red-50 text-red-600 border-red-200" },
-  past_due: { label: "Past Due", classes: "bg-orange-50 text-orange-600 border-orange-200" },
-};
-
-const roleBadgeClass = {
-  admin: "bg-yellow-100 text-yellow-800 border-yellow-300",
-  moderator: "bg-blue-100 text-blue-700 border-blue-200",
-  user: "bg-base-200 text-base-content/70 border-base-300",
-};
-
-// ─── Tab: Tickets ─────────────────────────────────────────────────────────────
-
-function TicketsTab({ tickets }) {
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState({ key: null, dir: "asc" });
-
-  const filtered = tickets.filter(
-    (t) =>
-      t.buyerEmail?.toLowerCase().includes(search.toLowerCase()) ||
-      t.eventId?.title?.toLowerCase().includes(search.toLowerCase())
-  );
-
-  const sorted = [...filtered].sort((a, b) => {
-    if (!sort.key) return 0;
-    let va, vb;
-    if (sort.key === "date") {
-      va = new Date(a.createdAt);
-      vb = new Date(b.createdAt);
-    } else if (sort.key === "paid") {
-      va = (a.eventId?.ticketPrice ?? 0) * (a.quantity ?? 1);
-      vb = (b.eventId?.ticketPrice ?? 0) * (b.quantity ?? 1);
-    } else if (sort.key === "quantity") {
-      va = a.quantity ?? 1;
-      vb = b.quantity ?? 1;
-    }
-    return sort.dir === "asc" ? va - vb : vb - va;
-  });
-
-  return (
-    <div>
-      <input
-        type="text"
-        placeholder="Search by buyer email or event…"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="glass-input mb-4"
-      />
-      <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
-        <table className="w-full text-sm min-w-[600px]">
-          <thead>
-            <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
-              <th className="px-4 py-3 font-semibold text-base-content">Event</th>
-              <th className="px-4 py-3 font-semibold text-base-content">Buyer Email</th>
-              <SortableHeader label="Qty" sortKey="quantity" sort={sort} onSort={setSort} />
-              <SortableHeader label="Paid" sortKey="paid" sort={sort} onSort={setSort} />
-              <SortableHeader label="Date" sortKey="date" sort={sort} onSort={setSort} />
-              <th className="px-4 py-3 font-semibold text-base-content">Ref</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-base-100">
-            {sorted.length === 0 ? (
-              <tr>
-                <td colSpan={6} className="text-center py-10 text-base-content/50">
-                  No tickets found
-                </td>
-              </tr>
-            ) : (
-              sorted.map((t) => (
-                <tr key={t._id} className="bg-white hover:bg-base-200/30 transition-colors">
-                  <td className="px-4 py-3 font-medium text-base-content">
-                    {t.eventId?.title ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 text-base-content/70">{t.buyerEmail}</td>
-                  <td className="px-4 py-3 text-base-content/70">{t.quantity ?? 1}</td>
-                  <td className="px-4 py-3 text-green-700 font-medium">
-                    £{((t.eventId?.ticketPrice ?? 0) * (t.quantity ?? 1)).toFixed(2)}
-                  </td>
-                  <td className="px-4 py-3 text-base-content/50">{formatDate(t.createdAt)}</td>
-                  <td className="px-4 py-3 font-mono text-[11px] text-base-content/40">
-                    {t.paymentId ? "…" + t.paymentId.slice(-8) : "—"}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-      <p className="text-xs text-base-content/50 mt-2">
-        {filtered.length} ticket{filtered.length !== 1 ? "s" : ""}
-      </p>
-    </div>
-  );
-}
-
-// ─── Tab: Revenue ─────────────────────────────────────────────────────────────
-
-function RevenueTab({ events }) {
-  const [sort, setSort] = useState({ key: null, dir: "asc" });
-
-  const chartData = {
-    labels: events.map((e) => e.title),
-    datasets: [
-      {
-        label: "Revenue (£)",
-        data: events.map((e) => e.totalRevenue ?? 0),
-        backgroundColor: "rgba(59, 130, 172, 0.6)",
-        borderColor: "rgba(59, 130, 172, 1)",
-        borderWidth: 1,
-        borderRadius: 6,
-      },
-    ],
-  };
-
-  const totalRevenue = events.reduce((sum, e) => sum + (e.totalRevenue ?? 0), 0);
-
-  const sorted = [...events].sort((a, b) => {
-    if (!sort.key) return 0;
-    let va, vb;
-    if (sort.key === "event")
-      return sort.dir === "asc"
-        ? (a.title ?? "").localeCompare(b.title ?? "")
-        : (b.title ?? "").localeCompare(a.title ?? "");
-    if (sort.key === "revenue") {
-      va = a.totalRevenue ?? 0;
-      vb = b.totalRevenue ?? 0;
-    } else if (sort.key === "tickets") {
-      va = a.ticketsAvailable ?? 0;
-      vb = b.ticketsAvailable ?? 0;
-    } else if (sort.key === "price") {
-      va = a.ticketPrice ?? 0;
-      vb = b.ticketPrice ?? 0;
-    }
-    return sort.dir === "asc" ? va - vb : vb - va;
-  });
-
-  return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
-          <p className="text-xs text-base-content/50 mb-1">Total Revenue</p>
-          <p className="text-2xl font-bold text-base-content">£{totalRevenue.toFixed(2)}</p>
-        </div>
-        <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
-          <p className="text-xs text-base-content/50 mb-1">Events with Sales</p>
-          <p className="text-2xl font-bold text-base-content">
-            {events.filter((e) => (e.totalRevenue ?? 0) > 0).length}
-          </p>
-        </div>
-        <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
-          <p className="text-xs text-base-content/50 mb-1">Total Events</p>
-          <p className="text-2xl font-bold text-base-content">{events.length}</p>
-        </div>
-      </div>
-
-      <div className="bg-white rounded-2xl border border-base-300 shadow-sm p-5">
-        <div className="h-72">
-          <Bar
-            data={chartData}
-            options={{
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: { legend: { display: false } },
-              scales: { y: { beginAtZero: true, ticks: { callback: (v) => "£" + v } } },
-            }}
-          />
-        </div>
-      </div>
-
-      <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
-        <table className="w-full text-sm min-w-[600px]">
-          <thead>
-            <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
-              <SortableHeader label="Event" sortKey="event" sort={sort} onSort={setSort} />
-              <SortableHeader label="Revenue" sortKey="revenue" sort={sort} onSort={setSort} />
-              <SortableHeader label="Tickets Left" sortKey="tickets" sort={sort} onSort={setSort} />
-              <SortableHeader label="Price/ticket" sortKey="price" sort={sort} onSort={setSort} />
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-base-100">
-            {sorted.map((e) => (
-              <tr key={e._id} className="bg-white hover:bg-base-200/30 transition-colors">
-                <td className="px-4 py-3 font-medium text-base-content">{e.title}</td>
-                <td className="px-4 py-3 text-green-700 font-medium">
-                  £{(e.totalRevenue ?? 0).toFixed(2)}
-                </td>
-                <td className="px-4 py-3 text-base-content/70">{e.ticketsAvailable ?? "—"}</td>
-                <td className="px-4 py-3 text-base-content/70">
-                  £{(e.ticketPrice ?? 0).toFixed(2)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-// ─── Tab: Teams ───────────────────────────────────────────────────────────────
-
-function TeamsTab({ teams }) {
-  const [expanded, setExpanded] = useState(null);
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState({ key: null, dir: "asc" });
-
-  const handleTeamSort = (key) => {
-    if (sort.key === key) {
-      setSort({ key, dir: sort.dir === "asc" ? "desc" : "asc" });
-    } else {
-      setSort({ key, dir: "asc" });
-    }
-  };
-
-  const filtered = teams.filter((t) => {
-    if (!search) return true;
-    const q = search.toLowerCase();
-    return (
-      t.name?.toLowerCase().includes(q) ||
-      t.manager?.name?.toLowerCase().includes(q) ||
-      t.manager?.email?.toLowerCase().includes(q) ||
-      t.manager?.phone?.includes(q) ||
-      t.members?.some(
-        (m) => m.name?.toLowerCase().includes(q) || m.email?.toLowerCase().includes(q)
-      )
-    );
-  });
-
-  const sorted = [...filtered].sort((a, b) => {
-    if (!sort.key) return 0;
-    let va, vb;
-    if (sort.key === "members") {
-      va = a.members?.length ?? 0;
-      vb = b.members?.length ?? 0;
-    } else if (sort.key === "paid") {
-      va = a.paid ? 1 : 0;
-      vb = b.paid ? 1 : 0;
-    }
-    return sort.dir === "asc" ? va - vb : vb - va;
-  });
-
-  const TEAM_SORT_OPTIONS = [
-    { key: "members", label: "Members" },
-    { key: "paid", label: "Payment" },
-  ];
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2 mb-1">
-        <input
-          type="text"
-          placeholder="Search teams, members, or email…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="glass-input flex-1 max-w-xs"
-        />
-        <div className="flex bg-base-200 rounded-xl p-1 gap-1">
-          {TEAM_SORT_OPTIONS.map((opt) => (
-            <button
-              key={opt.key}
-              onClick={() => handleTeamSort(opt.key)}
-              className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all cursor-pointer ${
-                sort.key === opt.key
-                  ? "bg-gradient-to-r from-primary to-primary/70 text-white shadow-sm"
-                  : "text-base-content/50 hover:text-base-content"
-              }`}
-            >
-              {opt.label}
-              {sort.key === opt.key && (
-                <svg
-                  className={`w-3 h-3 transition-transform ${sort.dir === "desc" ? "rotate-180" : ""}`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M5 15l7-7 7 7"
-                  />
-                </svg>
-              )}
-            </button>
-          ))}
-        </div>
-      </div>
-      {sorted.length === 0 && (
-        <p className="text-center text-base-content/50 py-12">No team registrations found</p>
-      )}
-      {sorted.map((team) => (
-        <div
-          key={team._id}
-          className="bg-white rounded-2xl border border-base-300 shadow-sm overflow-hidden"
-        >
-          <div className="px-5 py-4 flex items-start justify-between gap-3">
-            <div className="flex-1 min-w-0">
-              <p className="font-semibold text-base-content">{team.name}</p>
-              <p className="text-xs text-base-content/50 mt-0.5">
-                {team.event?.title ?? "Unknown event"}
-                {team.event?.date && <span> · {formatDate(team.event.date)}</span>}
-              </p>
-              <p className="text-xs text-base-content/50 mt-0.5">
-                Manager: {team.manager?.name} · {team.manager?.email}
-                {team.manager?.phone && ` · ${team.manager.phone}`}
-              </p>
-            </div>
-            <div className="flex flex-col items-end gap-1">
-              <span
-                className={
-                  "text-xs font-medium px-2 py-0.5 rounded-full border " +
-                  (team.paid
-                    ? "bg-green-50 text-green-700 border-green-200"
-                    : "bg-orange-50 text-orange-600 border-orange-200")
-                }
-              >
-                {team.paid ? "✓ Paid" : "Pending"}
-              </span>
-              <span className="text-xs text-base-content/50">
-                {team.members?.length ?? 0} members
-              </span>
-            </div>
-          </div>
-          {team.members?.length > 0 && (
-            <div className="px-5 pb-4">
-              <button
-                onClick={() => setExpanded(expanded === team._id ? null : team._id)}
-                className="text-xs text-base-content/70 hover:text-base-content font-medium flex items-center gap-1 cursor-pointer"
-              >
-                {expanded === team._id ? "Hide members" : "Show members"}
-                <svg
-                  className={
-                    "w-3 h-3 transition-transform " + (expanded === team._id ? "rotate-180" : "")
-                  }
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </button>
-              {expanded === team._id && (
-                <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5">
-                  {team.members.map((m, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center gap-2 text-xs text-base-content/70 bg-base-200/50 rounded-lg px-3 py-1.5"
-                    >
-                      <span className="w-5 h-5 rounded-full bg-base-200 text-base-content/70 font-bold flex items-center justify-center text-[10px]">
-                        {m.name?.[0]?.toUpperCase() ?? "?"}
-                      </span>
-                      <span>{m.name}</span>
-                      {m.email && <span className="text-base-content/50">· {m.email}</span>}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ─── Tab: Courses ─────────────────────────────────────────────────────────────
-
-function CoursesTab({ enrollments, courses }) {
-  const [search, setSearch] = useState("");
-  const [view, setView] = useState("enrollments");
-  const [enrollSort, setEnrollSort] = useState({ key: null, dir: "asc" });
-  const [courseSort, setCourseSort] = useState({ key: null, dir: "asc" });
-
-  const filteredEnrollments = enrollments.filter(
-    (e) =>
-      e.buyerEmail?.toLowerCase().includes(search.toLowerCase()) ||
-      e.buyerPhone?.includes(search) ||
-      e.courseId?.title?.toLowerCase().includes(search.toLowerCase())
-  );
-  const filteredCourses = courses.filter(
-    (c) =>
-      c.title?.toLowerCase().includes(search.toLowerCase()) ||
-      c.instructor?.toLowerCase().includes(search.toLowerCase())
-  );
-
-  const ENROLL_STATUS_ORDER = {
-    active: 0,
-    paid: 1,
-    pending: 2,
-    free: 3,
-    past_due: 4,
-    cancelled: 5,
-  };
-
-  const sortedEnrollments = [...filteredEnrollments].sort((a, b) => {
-    if (!enrollSort.key) return 0;
-    let va, vb;
-    if (enrollSort.key === "status") {
-      va = ENROLL_STATUS_ORDER[a.status] ?? 6;
-      vb = ENROLL_STATUS_ORDER[b.status] ?? 6;
-    } else if (enrollSort.key === "date") {
-      va = new Date(a.createdAt);
-      vb = new Date(b.createdAt);
-    }
-    return enrollSort.dir === "asc" ? va - vb : vb - va;
-  });
-
-  const sortedCourses = [...filteredCourses].sort((a, b) => {
-    if (!courseSort.key) return 0;
-    if (courseSort.key === "category")
-      return courseSort.dir === "asc"
-        ? (a.category ?? "").localeCompare(b.category ?? "")
-        : (b.category ?? "").localeCompare(a.category ?? "");
-    let va, vb;
-    if (courseSort.key === "price") {
-      va = a.price ?? 0;
-      vb = b.price ?? 0;
-    } else if (courseSort.key === "enrolled") {
-      va = a.currentEnrollment ?? 0;
-      vb = b.currentEnrollment ?? 0;
-    } else if (courseSort.key === "status") {
-      va = a.enrollmentOpen ? 1 : 0;
-      vb = b.enrollmentOpen ? 1 : 0;
-    }
-    return courseSort.dir === "asc" ? va - vb : vb - va;
-  });
-
-  return (
-    <div>
-      <div className="flex items-center gap-3 mb-4">
-        <input
-          type="text"
-          placeholder="Search courses or emails…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="glass-input flex-1"
-        />
-        <div className="flex bg-base-200 rounded-xl p-1 gap-1">
-          {["enrollments", "courses"].map((v) => (
-            <button
-              key={v}
-              onClick={() => setView(v)}
-              className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all capitalize cursor-pointer ${view === v ? "bg-white shadow-sm text-base-content" : "text-base-content/50 hover:text-base-content"}`}
-            >
-              {v}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {view === "enrollments" && (
-        <>
-          <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
-            <table className="w-full text-sm min-w-[600px]">
-              <thead>
-                <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
-                  <th className="px-4 py-3 font-semibold text-base-content">Course</th>
-                  <th className="px-4 py-3 font-semibold text-base-content">Buyer Email</th>
-                  <th className="px-4 py-3 font-semibold text-base-content">Phone</th>
-                  <th className="px-4 py-3 font-semibold text-base-content">Participants</th>
-                  <SortableHeader
-                    label="Status"
-                    sortKey="status"
-                    sort={enrollSort}
-                    onSort={setEnrollSort}
-                  />
-                  <SortableHeader
-                    label="Date"
-                    sortKey="date"
-                    sort={enrollSort}
-                    onSort={setEnrollSort}
-                  />
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-base-100">
-                {sortedEnrollments.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="text-center py-10 text-base-content/50">
-                      No enrollments found
-                    </td>
-                  </tr>
-                ) : (
-                  sortedEnrollments.map((e) => (
-                    <tr key={e._id} className="bg-white hover:bg-base-200/30 transition-colors">
-                      <td className="px-4 py-3 font-medium text-base-content">
-                        {e.courseId?.title ?? "—"}
-                      </td>
-                      <td className="px-4 py-3 text-base-content/70">{e.buyerEmail}</td>
-                      <td className="px-4 py-3 text-base-content/70">{e.buyerPhone || "—"}</td>
-                      <td className="px-4 py-3 text-base-content/70">
-                        {e.participants?.length > 0
-                          ? e.participants.map((p) => p.name).join(", ")
-                          : "—"}
-                      </td>
-                      <td className="px-4 py-3">
-                        {(() => {
-                          const st = ENROLLMENT_STATUS[e.status] ?? {
-                            label: e.status ?? "Unknown",
-                            classes: "bg-base-100 text-base-content/50 border-base-300",
-                          };
-                          return (
-                            <span
-                              className={`text-xs font-medium px-2 py-0.5 rounded-full border ${st.classes}`}
-                            >
-                              {st.label}
-                            </span>
-                          );
-                        })()}
-                      </td>
-                      <td className="px-4 py-3 text-base-content/50">{formatDate(e.createdAt)}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-          <p className="text-xs text-base-content/50 mt-2">
-            {filteredEnrollments.length} enrollment{filteredEnrollments.length !== 1 ? "s" : ""}
-          </p>
-        </>
-      )}
-
-      {view === "courses" && (
-        <>
-          <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
-            <table className="w-full text-sm min-w-[600px]">
-              <thead>
-                <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
-                  <th className="px-4 py-3 font-semibold text-base-content">Title</th>
-                  <th className="px-4 py-3 font-semibold text-base-content">Instructor</th>
-                  <SortableHeader
-                    label="Category"
-                    sortKey="category"
-                    sort={courseSort}
-                    onSort={setCourseSort}
-                  />
-                  <SortableHeader
-                    label="Price"
-                    sortKey="price"
-                    sort={courseSort}
-                    onSort={setCourseSort}
-                  />
-                  <SortableHeader
-                    label="Enrolled"
-                    sortKey="enrolled"
-                    sort={courseSort}
-                    onSort={setCourseSort}
-                  />
-                  <SortableHeader
-                    label="Status"
-                    sortKey="status"
-                    sort={courseSort}
-                    onSort={setCourseSort}
-                  />
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-base-100">
-                {sortedCourses.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="text-center py-10 text-base-content/50">
-                      No courses found
-                    </td>
-                  </tr>
-                ) : (
-                  sortedCourses.map((c) => (
-                    <tr key={c._id} className="bg-white hover:bg-base-200/30 transition-colors">
-                      <td className="px-4 py-3 font-medium text-base-content">{c.title}</td>
-                      <td className="px-4 py-3 text-base-content/70">{c.instructor}</td>
-                      <td className="px-4 py-3 text-base-content/70">{c.category}</td>
-                      <td className="px-4 py-3 text-base-content/70">
-                        {c.price > 0 ? `£${c.price}` : "Free"}
-                      </td>
-                      <td className="px-4 py-3 text-base-content/70">
-                        {c.currentEnrollment}
-                        {c.maxEnrollment ? ` / ${c.maxEnrollment}` : ""}
-                      </td>
-                      <td className="px-4 py-3">
-                        <span
-                          className={`text-xs font-medium px-2 py-0.5 rounded-full border ${c.enrollmentOpen ? "bg-green-50 text-green-700 border-green-200" : "bg-base-100 text-base-content/50 border-base-300"}`}
-                        >
-                          {c.enrollmentOpen ? "Open" : "Closed"}
-                        </span>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-          <p className="text-xs text-base-content/50 mt-2">
-            {filteredCourses.length} course{filteredCourses.length !== 1 ? "s" : ""}
-          </p>
-        </>
-      )}
-    </div>
-  );
-}
-
-// ─── Tab: Users (admin only) ──────────────────────────────────────────────────
-
-const ROLE_ORDER = { admin: 0, moderator: 1, user: 2 };
-
-function UsersTab({ users, currentUserId, onRoleChange }) {
-  const [updating, setUpdating] = useState(null);
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState({ key: null, dir: "asc" });
-
-  const filtered = users.filter(
-    (u) =>
-      u.name?.toLowerCase().includes(search.toLowerCase()) ||
-      u.email?.toLowerCase().includes(search.toLowerCase())
-  );
-
-  const sorted = [...filtered].sort((a, b) => {
-    if (!sort.key) return 0;
-    let va, vb;
-    if (sort.key === "role") {
-      va = ROLE_ORDER[a.role] ?? 3;
-      vb = ROLE_ORDER[b.role] ?? 3;
-    } else if (sort.key === "joined") {
-      va = new Date(a.createdAt);
-      vb = new Date(b.createdAt);
-    }
-    return sort.dir === "asc" ? va - vb : vb - va;
-  });
-
-  const handleRole = async (userId, newRole) => {
-    setUpdating(userId);
-    const token = getAuthToken();
-    try {
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}admin/users/${userId}/role`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer " + token,
-        },
-        body: JSON.stringify({ role: newRole }),
-      });
-      const data = await res.json();
-      if (res.ok) onRoleChange(userId, newRole);
-      else alert(data.message);
-    } catch {
-      alert("Failed to update role");
-    } finally {
-      setUpdating(null);
-    }
-  };
-
-  return (
-    <div>
-      <input
-        type="text"
-        placeholder="Search by name or email…"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        className="glass-input mb-4"
-      />
-      <div className="overflow-x-auto rounded-2xl border border-base-300 shadow-sm">
-        <table className="w-full text-sm min-w-[600px]">
-          <thead>
-            <tr className="bg-gradient-to-r from-base-200 to-base-200 text-left">
-              <th className="px-4 py-3 font-semibold text-base-content">Name</th>
-              <th className="px-4 py-3 font-semibold text-base-content">Email</th>
-              <SortableHeader label="Role" sortKey="role" sort={sort} onSort={setSort} />
-              <SortableHeader label="Joined" sortKey="joined" sort={sort} onSort={setSort} />
-              <th className="px-4 py-3 font-semibold text-base-content">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-base-100">
-            {sorted.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="text-center py-10 text-base-content/50">
-                  No users found
-                </td>
-              </tr>
-            ) : (
-              sorted.map((u) => (
-                <tr key={u._id} className="bg-white hover:bg-base-200/30 transition-colors">
-                  <td className="px-4 py-3 font-medium text-base-content">{u.name}</td>
-                  <td className="px-4 py-3 text-base-content/70">{u.email}</td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={
-                        "text-xs font-medium px-2 py-0.5 rounded-full border capitalize " +
-                        (roleBadgeClass[u.role] ?? roleBadgeClass.user)
-                      }
-                    >
-                      {u.role}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-base-content/50">{formatDate(u.createdAt)}</td>
-                  <td className="px-4 py-3">
-                    {u._id === currentUserId ? (
-                      <span className="text-xs text-base-content/50 italic">you</span>
-                    ) : (
-                      <select
-                        value={u.role}
-                        disabled={updating === u._id}
-                        onChange={(e) => handleRole(u._id, e.target.value)}
-                        className="glass-input glass-select text-xs px-2 py-1 disabled:opacity-50"
-                      >
-                        <option value="user">user</option>
-                        <option value="moderator">moderator</option>
-                        <option value="admin">admin</option>
-                      </select>
-                    )}
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
-      <p className="text-xs text-base-content/50 mt-2">
-        {filtered.length} user{filtered.length !== 1 ? "s" : ""}
-      </p>
-    </div>
-  );
-}
-
-// ─── Main Dashboard ───────────────────────────────────────────────────────────
 
 export default function AdminDashboard() {
   const [data, setData] = useState(null);
@@ -776,7 +37,6 @@ export default function AdminDashboard() {
   const role = getRole();
   const isAdmin = role === "admin";
 
-  // Get current user id from token
   let currentUserId = null;
   try {
     const token = getAuthToken();
@@ -835,90 +95,95 @@ export default function AdminDashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-tr from-base-200 via-white to-base-200 py-10 px-4">
-      <div className="max-w-5xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-          <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-base-content">
-              {isAdmin ? "Admin Dashboard" : "Moderator Dashboard"}
-            </h1>
-            <p className="text-xs sm:text-sm text-base-content/50 mt-0.5">
-              {isAdmin
-                ? "Full access — manage events, users, and view all data"
-                : "View-only access to tickets, revenue, and teams"}
-            </p>
-          </div>
-          <span
-            className={
-              "text-xs font-medium px-3 py-1 rounded-full border capitalize shrink-0 " +
-              (roleBadgeClass[role] ?? roleBadgeClass.user)
-            }
-          >
-            {role}
-          </span>
-        </div>
+    <div className="min-h-screen bg-gradient-to-tr from-base-200 via-white to-base-200 pt-10 px-4 pb-10">
+      <div className="max-w-5xl mx-auto">
+        {/* Sticky header + tabs */}
+        <div className="sticky top-0 z-20 pb-6 -mx-4 px-4 [mask-image:linear-gradient(black_85%,transparent)] backdrop-blur-xl">
+          <div className="max-w-5xl mx-auto space-y-4 pt-1">
+            {/* Header */}
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
+              <div>
+                <h1 className="text-xl sm:text-2xl font-bold text-base-content">
+                  {isAdmin ? "Admin Dashboard" : "Moderator Dashboard"}
+                </h1>
+                <p className="text-xs sm:text-sm text-base-content/50 mt-0.5">
+                  {isAdmin
+                    ? "Full access — manage events, users, and view all data"
+                    : "View-only access to tickets, revenue, and teams"}
+                </p>
+              </div>
+              <span
+                className={
+                  "text-xs font-medium px-3 py-1 rounded-full border capitalize shrink-0 " +
+                  (roleBadgeClass[role] ?? roleBadgeClass.user)
+                }
+              >
+                {role}
+              </span>
+            </div>
 
-        {/* Tabs */}
-        <div className="flex gap-1 bg-white/70 backdrop-blur-sm rounded-2xl border border-base-300 shadow-sm p-1.5 overflow-x-auto">
-          {visibleTabs.map((tab) => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={
-                "flex-1 py-2 px-3 rounded-xl text-xs sm:text-sm font-medium transition-all whitespace-nowrap cursor-pointer " +
-                (activeTab === tab
-                  ? "bg-gradient-to-r from-primary to-primary/70 text-white shadow-sm"
-                  : "text-base-content/50 hover:text-base-content hover:bg-base-100")
-              }
-            >
-              {tab}
-              {tab === "Tickets" && data && (
-                <span
+            {/* Tabs */}
+            <div className="flex gap-1 bg-white/70 backdrop-blur-sm rounded-2xl border border-base-300 shadow-sm p-1.5 overflow-x-auto">
+              {visibleTabs.map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setActiveTab(tab)}
                   className={
-                    "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
-                    (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
+                    "flex-1 py-2 px-3 rounded-xl text-xs sm:text-sm font-medium transition-all whitespace-nowrap cursor-pointer " +
+                    (activeTab === tab
+                      ? "bg-gradient-to-r from-primary to-primary/70 text-white shadow-sm"
+                      : "text-base-content/50 hover:text-base-content hover:bg-base-100")
                   }
                 >
-                  {data.tickets.length}
-                </span>
-              )}
-              {tab === "Teams" && data && (
-                <span
-                  className={
-                    "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
-                    (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
-                  }
-                >
-                  {data.teams.length}
-                </span>
-              )}
-              {tab === "Courses" && data?.enrollments && (
-                <span
-                  className={
-                    "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
-                    (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
-                  }
-                >
-                  {data.enrollments.length}
-                </span>
-              )}
-              {tab === "Users" && data?.users && (
-                <span
-                  className={
-                    "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
-                    (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
-                  }
-                >
-                  {data.users.length}
-                </span>
-              )}
-            </button>
-          ))}
+                  {tab}
+                  {tab === "Tickets" && data && (
+                    <span
+                      className={
+                        "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
+                        (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
+                      }
+                    >
+                      {data.tickets.length}
+                    </span>
+                  )}
+                  {tab === "Teams" && data && (
+                    <span
+                      className={
+                        "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
+                        (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
+                      }
+                    >
+                      {data.teams.length}
+                    </span>
+                  )}
+                  {tab === "Courses" && data?.enrollments && (
+                    <span
+                      className={
+                        "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
+                        (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
+                      }
+                    >
+                      {data.enrollments.length}
+                    </span>
+                  )}
+                  {tab === "Users" && data?.users && (
+                    <span
+                      className={
+                        "ml-1.5 text-xs px-1.5 py-0.5 rounded-full " +
+                        (activeTab === tab ? "bg-white/20" : "bg-base-200 text-base-content/50")
+                      }
+                    >
+                      {data.users.length}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
 
         {/* Tab content */}
-        <div className="bg-white/70 backdrop-blur-sm rounded-2xl sm:rounded-3xl border border-base-300 shadow-sm p-3 sm:p-6">
+        <div className="bg-white/70 backdrop-blur-sm rounded-2xl sm:rounded-3xl border border-base-300 shadow-sm p-3 sm:p-6 mt-2">
           {activeTab === "Tickets" && <TicketsTab tickets={data.tickets} />}
           {activeTab === "Revenue" && <RevenueTab events={data.events} />}
           {activeTab === "Teams" && <TeamsTab teams={data.teams} />}

--- a/src/pages/tickets/TicketPage.jsx
+++ b/src/pages/tickets/TicketPage.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Link, useParams, useNavigate } from "react-router-dom";
+import { Link, useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { isAuthenticated, getAuthToken } from "../../auth/auth";
 import TicketCard from "../../components/tickets/TicketCard";
 import { PageContainer, GlassCard, Spinner } from "../../components/ui";
 
 export default function TicketPage() {
   const { ticketCode } = useParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const [ticket, setTicket] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -28,6 +29,14 @@ export default function TicketPage() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [ticketCode, navigate]);
+
+  // Auto-print when opened with ?print=true (e.g. from admin dashboard)
+  useEffect(() => {
+    if (ticket && searchParams.get("print") === "true") {
+      const timer = setTimeout(() => window.print(), 400);
+      return () => clearTimeout(timer);
+    }
+  }, [ticket, searchParams]);
 
   if (loading)
     return (


### PR DESCRIPTION
… reset bug

Split AdminDashboard.jsx into separate components under components/admin/: TicketsTab, RevenueTab, TeamsTab, CoursesTab, UsersTab, Pagination, and shared helpers. Add ticket grouping by paymentId, clickable rows, print buttons, and pagination across all data tabs. Fix pagination not resetting to page 1 on sort/filter changes by using useEffect instead of render-time state mutation. Add auto-print support to TicketPage via ?print=true param.