### PR TITLE
Refactor event and course details: extract components, unify admin to…

### DIFF
--- a/__tests__/components/admin/UsersTab.test.jsx
+++ b/__tests__/components/admin/UsersTab.test.jsx
@@ -6,15 +6,15 @@ import "@testing-library/jest-dom";
 // Mock auth
 jest.mock("../../../src/auth/auth", () => ({
   getAuthToken: () => "mock-token",
+  fetchWithAuth: jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ message: "Role updated" }),
+    })
+  ),
 }));
 
-// Mock fetch for role change
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({ message: "Role updated" }),
-  })
-);
+import { fetchWithAuth } from "../../../src/auth/auth";
 
 const users = [
   {
@@ -87,7 +87,7 @@ describe("UsersTab", () => {
       fireEvent.change(selects[0], { target: { value: "admin" } });
     });
 
-    expect(global.fetch).toHaveBeenCalled();
+    expect(fetchWithAuth).toHaveBeenCalled();
     expect(onRoleChange).toHaveBeenCalledWith("u2", "admin");
   });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ const CoursesPage = lazy(() => import("./pages/courses/Courses"));
 const CourseConfirmation = lazy(() => import("./pages/courses/CourseConfirmation"));
 const CourseDetails = lazy(() => import("./pages/courses/CourseDetails"));
 const CourseFormPage = lazy(() => import("./pages/courses/CourseFormPage"));
+const CourseRoot = lazy(() => import("./pages/courses/CourseRoot"));
 
 const fallback = (
   <div className="flex justify-center items-center p-12">
@@ -60,13 +61,19 @@ const router = createBrowserRouter([
       { path: "profile", element: w(ProfilePage) },
       { path: "tickets/:ticketCode", element: w(TicketPage) },
       { path: "tickets/verify/:ticketCode", element: w(TicketVerify) },
-      { path: "courses", element: w(CoursesPage) },
-      { path: "courses/:courseSlug", element: w(CourseDetails) },
       {
-        element: <ModeratorRoute />,
+        path: "courses",
+        element: w(CourseRoot),
         children: [
-          { path: "courses/new", element: w(CourseFormPage), action: courseAction },
-          { path: "courses/:courseSlug/edit", element: w(CourseFormPage), action: courseAction },
+          { index: true, element: w(CoursesPage) },
+          { path: ":courseSlug", element: w(CourseDetails) },
+          {
+            element: <ModeratorRoute />,
+            children: [
+              { path: "new", element: w(CourseFormPage), action: courseAction },
+              { path: ":courseSlug/edit", element: w(CourseFormPage), action: courseAction },
+            ],
+          },
         ],
       },
       { path: "course-confirmation", element: w(CourseConfirmation) },

--- a/src/api/courseActions.js
+++ b/src/api/courseActions.js
@@ -1,5 +1,5 @@
 import { redirect } from "react-router-dom";
-import { getAuthToken } from "../auth/auth";
+import { fetchWithAuth } from "../auth/auth";
 import { compressImage } from "../util/compressImage";
 import { slugToId } from "../util/util";
 
@@ -28,7 +28,6 @@ export async function courseAction({ request, params }) {
     featured: formData.get("featured") === "true",
   };
 
-  const token = getAuthToken();
   const body = new FormData();
   body.append("courseData", JSON.stringify(courseData));
   const imageFile = formData.get("image");
@@ -43,7 +42,7 @@ export async function courseAction({ request, params }) {
     : `${import.meta.env.VITE_DEV_URI}courses`;
 
   try {
-    const res = await fetch(url, { method, headers: { Authorization: `Bearer ${token}` }, body });
+    const res = await fetchWithAuth(url, { method, body });
     const resData = await res.json().catch(() => ({}));
     if (!res.ok)
       return { errors: { message: resData.error || resData.message || "Unknown error" } };

--- a/src/api/eventActions.js
+++ b/src/api/eventActions.js
@@ -1,5 +1,5 @@
 import { redirect } from "react-router-dom";
-import { getAuthToken } from "../auth/auth";
+import { fetchWithAuth } from "../auth/auth";
 import { compressImage } from "../util/compressImage";
 import { slugToId } from "../util/util";
 
@@ -31,8 +31,6 @@ export async function eventAction({ request, params }) {
       data.get("ticketsAvailable") !== "" ? parseInt(data.get("ticketsAvailable"), 10) : undefined,
   };
 
-  const token = getAuthToken();
-
   const formData = new FormData();
   formData.append("eventData", JSON.stringify(eventData));
   const imageFile = data.get("image");
@@ -49,11 +47,8 @@ export async function eventAction({ request, params }) {
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithAuth(url, {
       method: method,
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
       body: formData,
     });
 

--- a/src/auth/auth.js
+++ b/src/auth/auth.js
@@ -45,13 +45,21 @@ export async function refreshAccessToken() {
         credentials: "include",
       });
       if (!res.ok) {
+        if (import.meta.env.DEV) {
+          console.debug(
+            `[auth] refreshAccessToken: ${res.status} ${res.statusText} — cookie likely missing or expired`
+          );
+        }
         clearAuth();
         return false;
       }
       const data = await res.json();
       setAuth(data.accessToken, data.user);
       return true;
-    } catch {
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.debug("[auth] refreshAccessToken threw:", err);
+      }
       clearAuth();
       return false;
     } finally {

--- a/src/components/admin/UsersTab.jsx
+++ b/src/components/admin/UsersTab.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { getAuthToken } from "../../auth/auth";
+import { fetchWithAuth } from "../../auth/auth";
 import SortableHeader from "../common/SortableHeader";
 import { formatDate, roleBadgeClass, usePagination } from "./adminHelpers";
 import Pagination from "./Pagination";
@@ -34,14 +34,10 @@ export default function UsersTab({ users, currentUserId, onRoleChange }) {
 
   const handleRole = async (userId, newRole) => {
     setUpdating(userId);
-    const token = getAuthToken();
     try {
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}admin/users/${userId}/role`, {
+      const res = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}admin/users/${userId}/role`, {
         method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer " + token,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ role: newRole }),
       });
       const data = await res.json();

--- a/src/components/courses/CourseCard.jsx
+++ b/src/components/courses/CourseCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
+import { isAdmin, isModerator, fetchWithAuth } from "../../auth/auth";
 import { optimizeCloudinaryUrl, toSlug } from "../../util/util";
 import { Badge, GlassCard } from "../ui";
 
@@ -24,9 +24,8 @@ export default function CourseCard({ course }) {
     if (!window.confirm(`Delete "${course.title}"? This cannot be undone.`)) return;
     setDeleting(true);
     try {
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}courses/${course._id}`, {
+      const res = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}courses/${course._id}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${getAuthToken()}` },
       });
       if (res.ok) window.location.reload();
     } catch (err) {

--- a/src/components/courses/CourseHeader.jsx
+++ b/src/components/courses/CourseHeader.jsx
@@ -3,13 +3,12 @@ import { useRouteLoaderData, useLocation, useParams } from "react-router-dom";
 import { isAdmin, isModerator } from "../../auth/auth";
 import { Button } from "../ui";
 
-const EventHeader = () => {
+const CourseHeader = () => {
   const { token } = useRouteLoaderData("root");
   const location = useLocation();
-  const { eventSlug } = useParams();
+  const { courseSlug } = useParams();
 
-  // Hide on create/edit pages — the form itself is the focus
-  if (/\/events\/(new|[^/]+\/edit)/.test(location.pathname)) {
+  if (/\/courses\/(new|[^/]+\/edit)/.test(location.pathname)) {
     return null;
   }
 
@@ -17,7 +16,7 @@ const EventHeader = () => {
     return null;
   }
 
-  const isDetailPage = !!eventSlug;
+  const isDetailPage = !!courseSlug;
 
   return (
     <div className="container mx-auto px-6 pt-6">
@@ -34,17 +33,17 @@ const EventHeader = () => {
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 strokeWidth={2}
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
               />
             </svg>
           </div>
-          <span className="text-sm font-semibold text-base-content">Event Management</span>
+          <span className="text-sm font-semibold text-base-content">Course Management</span>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
           {isDetailPage && (
             <Button
               variant="primary"
-              to={`/events/${eventSlug}/edit`}
+              to={`/courses/${courseSlug}/edit`}
               className="shadow-md shadow-primary/20"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -55,10 +54,10 @@ const EventHeader = () => {
                   d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
                 />
               </svg>
-              Edit Event
+              Edit Course
             </Button>
           )}
-          <Button variant="primary" to="/events/new" className="shadow-md shadow-primary/20">
+          <Button variant="primary" to="/courses/new" className="shadow-md shadow-primary/20">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
                 strokeLinecap="round"
@@ -67,7 +66,7 @@ const EventHeader = () => {
                 d="M12 4v16m8-8H4"
               />
             </svg>
-            Create Event
+            Create Course
           </Button>
         </div>
       </div>
@@ -75,4 +74,4 @@ const EventHeader = () => {
   );
 };
 
-export default EventHeader;
+export default CourseHeader;

--- a/src/components/courses/EnrolledPanel.jsx
+++ b/src/components/courses/EnrolledPanel.jsx
@@ -1,0 +1,258 @@
+import { useState } from "react";
+import { fetchWithAuth } from "../../auth/auth";
+import { Button } from "../ui";
+
+const INTERVAL_LABELS = { month: "month", year: "year" };
+const INTERVAL_ADJ = { month: "Monthly", year: "Yearly" };
+
+const STATUS_STYLES = {
+  active: "bg-green-100 text-green-700",
+  paid: "bg-blue-100 text-blue-700",
+  free: "bg-teal-100 text-teal-700",
+  past_due: "bg-amber-100 text-amber-700",
+};
+
+const STATUS_LABELS = {
+  active: "Active Subscription",
+  paid: "Enrolled",
+  free: "Enrolled (Free)",
+  past_due: "Past Due",
+};
+
+function formatDate(d) {
+  return new Date(d).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default function EnrolledPanel({ course, enrollment, onChanged }) {
+  const [newParticipant, setNewParticipant] = useState({ name: "", age: "", email: "" });
+  const [addingParticipant, setAddingParticipant] = useState(false);
+  const [addParticipantError, setAddParticipantError] = useState("");
+  const [cancellingSubscription, setCancellingSubscription] = useState(false);
+  const [reactivatingSubscription, setReactivatingSubscription] = useState(false);
+  const [subscriptionError, setSubscriptionError] = useState("");
+
+  const isCancelled = enrollment.subscriptionStatus === "cancelled";
+
+  const handleAddParticipant = async () => {
+    setAddParticipantError("");
+    if (!newParticipant.name.trim()) {
+      setAddParticipantError("Name is required.");
+      return;
+    }
+    try {
+      setAddingParticipant(true);
+      const res = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}courses/enrollments/${enrollment._id}/add-participant`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newParticipant),
+        }
+      );
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to add participant");
+      setNewParticipant({ name: "", age: "", email: "" });
+      onChanged();
+    } catch (err) {
+      setAddParticipantError(err.message);
+    } finally {
+      setAddingParticipant(false);
+    }
+  };
+
+  const handleCancelSubscription = async () => {
+    setSubscriptionError("");
+    setCancellingSubscription(true);
+    try {
+      const res = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}courses/enrollments/${enrollment._id}/cancel`,
+        { method: "POST" }
+      );
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to cancel subscription");
+      onChanged();
+    } catch (err) {
+      setSubscriptionError(err.message);
+    } finally {
+      setCancellingSubscription(false);
+    }
+  };
+
+  const handleReactivateSubscription = async () => {
+    setSubscriptionError("");
+    setReactivatingSubscription(true);
+    try {
+      const res = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}courses/enrollments/${enrollment._id}/reactivate`,
+        { method: "POST" }
+      );
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to reactivate subscription");
+      if (data.url) {
+        window.location.href = data.url;
+        return;
+      }
+      onChanged();
+    } catch (err) {
+      setSubscriptionError(err.message);
+    } finally {
+      setReactivatingSubscription(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 mb-2">
+        <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
+          <svg
+            className="w-5 h-5 text-green-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </div>
+        <h2 className="text-xl font-bold text-base-content">You're Enrolled</h2>
+      </div>
+
+      <span
+        className={`inline-block text-xs font-semibold px-3 py-1 rounded-full ${
+          isCancelled
+            ? "bg-orange-100 text-orange-700"
+            : STATUS_STYLES[enrollment.status] || "bg-base-200 text-base-content"
+        }`}
+      >
+        {isCancelled ? "Cancelled" : STATUS_LABELS[enrollment.status] || enrollment.status}
+      </span>
+
+      {enrollment.subscriptionId && isCancelled && (
+        <div className="bg-orange-50 border border-orange-200 rounded-xl p-3 text-xs text-orange-700">
+          <p className="font-semibold mb-1">You have cancelled your subscription</p>
+          <p>You'll retain access until the end of your current billing period.</p>
+          {enrollment.currentPeriodEnd && (
+            <p className="mt-1 font-medium text-orange-600">
+              Access until {formatDate(enrollment.currentPeriodEnd)}
+            </p>
+          )}
+        </div>
+      )}
+
+      {enrollment.subscriptionId && !isCancelled && (
+        <div className="bg-blue-50 border border-blue-200 rounded-xl p-3 text-xs text-blue-700">
+          <p className="font-semibold mb-1">
+            {INTERVAL_ADJ[course.billingInterval] || "Monthly"} Subscription
+          </p>
+          <p>
+            £{course.price} / {INTERVAL_LABELS[course.billingInterval] || "month"}
+          </p>
+          {enrollment.currentPeriodEnd && (
+            <p className="mt-1 text-blue-600">Renews {formatDate(enrollment.currentPeriodEnd)}</p>
+          )}
+        </div>
+      )}
+
+      <div>
+        <p className="text-sm font-semibold text-base-content mb-2">
+          Participants ({enrollment.participants?.length || 0})
+        </p>
+        <div className="space-y-1.5">
+          {enrollment.participants?.map((p, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 bg-base-200/50 rounded-lg px-3 py-2 text-sm"
+            >
+              <div className="w-6 h-6 rounded-full bg-gradient-to-br from-primary to-secondary flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+                {p.name.charAt(0).toUpperCase()}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-base-content truncate">{p.name}</p>
+                {p.age && <p className="text-xs text-base-content/50">Age {p.age}</p>}
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-base-content/50 mt-2">
+          To remove a participant, use <span className="font-medium">Manage in Profile</span> below.
+        </p>
+      </div>
+
+      {enrollment.status !== "cancelled" && !isCancelled && (
+        <div className="border-t border-base-300/50 pt-4">
+          <p className="text-sm font-semibold text-base-content mb-2">Add Participant</p>
+          <div className="space-y-2">
+            <input
+              type="text"
+              placeholder="Name *"
+              value={newParticipant.name}
+              onChange={(e) => setNewParticipant((p) => ({ ...p, name: e.target.value }))}
+              className="glass-input text-sm py-1.5"
+            />
+            <input
+              type="number"
+              placeholder="Age"
+              min="1"
+              value={newParticipant.age}
+              onChange={(e) => setNewParticipant((p) => ({ ...p, age: e.target.value }))}
+              className="glass-input text-sm py-1.5"
+            />
+            {addParticipantError && <p className="text-red-500 text-xs">{addParticipantError}</p>}
+            <Button
+              variant="primary"
+              onClick={handleAddParticipant}
+              disabled={addingParticipant}
+              className="w-full text-sm"
+            >
+              {addingParticipant ? "Adding..." : "+ Add Participant"}
+            </Button>
+            {course.isSubscription && (
+              <p className="text-xs text-base-content/50 text-center">
+                Adding a participant will increase your subscription billing.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {enrollment.subscriptionId && (
+        <div className="border-t border-base-300/50 pt-4 space-y-2">
+          {isCancelled ? (
+            <Button
+              variant="primary"
+              onClick={handleReactivateSubscription}
+              disabled={reactivatingSubscription}
+              className="w-full text-sm"
+            >
+              {reactivatingSubscription ? "Reactivating..." : "Reactivate Subscription"}
+            </Button>
+          ) : (
+            <Button
+              variant="danger"
+              onClick={handleCancelSubscription}
+              disabled={cancellingSubscription}
+              className="w-full text-sm"
+            >
+              {cancellingSubscription ? "Cancelling..." : "Cancel Subscription"}
+            </Button>
+          )}
+          {subscriptionError && (
+            <p className="text-red-500 text-xs text-center">{subscriptionError}</p>
+          )}
+        </div>
+      )}
+
+      <Button variant="ghost" to="/profile" className="w-full text-sm">
+        Manage in Profile
+      </Button>
+    </div>
+  );
+}

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Link, useNavigate, useRouteLoaderData } from "react-router-dom";
-import { isAdmin, isModerator } from "../../auth/auth";
+import { Link, useNavigate } from "react-router-dom";
+import { isAdmin, isModerator, fetchWithAuth } from "../../auth/auth";
 import { formatDateRange, optimizeCloudinaryUrl, toSlug } from "../../util/util";
 import ConfirmModal from "../common/ConfirmModal";
 import { Badge, GlassCard } from "../ui";
@@ -11,7 +11,6 @@ const TYPE_COLORS = {
 };
 
 export default function EventCard({ event }) {
-  const { token } = useRouteLoaderData("root");
   const canManage = isAdmin() || isModerator();
   const navigate = useNavigate();
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -30,9 +29,8 @@ export default function EventCard({ event }) {
     setConfirmOpen(false);
     setDeleteError(null);
     try {
-      const response = await fetch(`${import.meta.env.VITE_DEV_URI}events/${event._id}`, {
+      const response = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}events/${event._id}`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (!response.ok) {
         const errorData = await response.json();

--- a/src/components/events/EventDetailsBanner.jsx
+++ b/src/components/events/EventDetailsBanner.jsx
@@ -1,0 +1,30 @@
+export default function EventDetailsBanner({ event }) {
+  return (
+    <div className="bg-gradient-to-r from-primary to-secondary text-white p-6 md:p-12 shadow-lg backdrop-blur-sm">
+      <div className="container mx-auto">
+        <h1 className="text-3xl md:text-5xl font-bold text-center mb-2">{event.title}</h1>
+        {event.organizer && (
+          <p className="text-center text-lg">
+            <span className="flex items-center justify-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-2"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                />
+              </svg>
+              {event.organizer}
+            </span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/EventInfoGrid.jsx
+++ b/src/components/events/EventInfoGrid.jsx
@@ -1,0 +1,183 @@
+import { getNextRecurringDate, capitalize } from "../../util/util";
+import { Badge, GlassCard } from "../ui";
+
+export default function EventInfoGrid({ event }) {
+  return (
+    <GlassCard className="shadow-xl">
+      <div className="card-body">
+        <h2 className="card-title text-xl text-base-content">Event Details:</h2>
+        {(event.isReoccurring || event.typeOfEvent) && (
+          <div className="flex flex-wrap items-center gap-2">
+            {event.typeOfEvent && (
+              <Badge color={event.typeOfEvent === "Sports" ? "accent" : "primary"}>
+                {event.typeOfEvent}
+              </Badge>
+            )}
+            {event.isReoccurring && event.dayOfWeek && (
+              <Badge color="secondary">↻ Weekly · {capitalize(event.dayOfWeek)}s</Badge>
+            )}
+          </div>
+        )}
+        <div className="space-y-4">
+          {event.isReoccurring &&
+            (() => {
+              const next = getNextRecurringDate(event);
+              if (!next) return null;
+              return (
+                <div className="flex items-start">
+                  <div className="bg-gradient-to-br from-secondary to-primary text-white p-3 rounded-xl mr-4 shadow-md">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-6 w-6"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-lg text-base-content">Next Session</h3>
+                    <p className="text-base-content/70">
+                      {next.toLocaleDateString("en-GB", {
+                        weekday: "long",
+                        day: "numeric",
+                        month: "long",
+                        year: "numeric",
+                      })}
+                      {event.openingTime ? ` · ${event.openingTime}` : ""}
+                    </p>
+                  </div>
+                </div>
+              );
+            })()}
+          <div className="flex items-start">
+            <div className="bg-gradient-to-br from-primary to-secondary text-white p-3 rounded-xl mr-4 shadow-md">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h3 className="font-bold text-lg text-base-content">
+                {event.isReoccurring ? "Series" : "Date & Time"}
+              </h3>
+              <p className="text-base-content/70">
+                {event.isReoccurring && event.reoccurringStartDate && event.reoccurringEndDate
+                  ? `${new Date(event.reoccurringStartDate).toLocaleDateString()} – ${new Date(event.reoccurringEndDate).toLocaleDateString()}`
+                  : `${new Date(event.date).toLocaleDateString()}${event.openingTime ? ", " + event.openingTime : ""}`}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-start">
+            <div className="bg-gradient-to-br from-primary to-secondary text-white p-3 rounded-xl mr-4 shadow-md">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+            </div>
+            <div>
+              <h3 className="font-bold text-lg text-base-content">Location</h3>
+              <p className="text-base-content/70">
+                {event.street}, {event.city}, {event.postCode}
+              </p>
+            </div>
+          </div>
+
+          {event.ticketPrice > 0 && (
+            <div className="flex items-start">
+              <div className="bg-gradient-to-br from-secondary to-primary text-white p-3 rounded-xl mr-4 shadow-md">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-6 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"
+                  />
+                </svg>
+              </div>
+              <div>
+                <h3 className="font-bold text-lg text-base-content">
+                  {event.isTournament ? "Tournament Fee" : "Ticket Price"}
+                </h3>
+                <p className="text-base-content/70">£{event.ticketPrice}</p>
+                {event.isTournament && (
+                  <p className="text-xs text-base-content/50 mt-0.5">
+                    Per player — spectators enter free
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {event.ticketsAvailable !== undefined && (
+            <div className="flex items-start">
+              <div className="bg-gradient-to-br from-green-500 to-teal-600 text-white p-3 rounded-xl mr-4 shadow-md">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-6 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+              </div>
+              <div>
+                <h3 className="font-bold text-lg text-base-content">Availability</h3>
+                <p className="text-base-content/70">
+                  {event.ticketsAvailable > 0
+                    ? `${event.ticketsAvailable} tickets remaining`
+                    : "Sold out"}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/events/MyTeamsSection.jsx
+++ b/src/components/events/MyTeamsSection.jsx
@@ -1,0 +1,59 @@
+import MyTeamRow from "../teams/MyTeamRow";
+import { Button, GlassCard } from "../ui";
+
+export default function MyTeamsSection({ teams }) {
+  if (!teams?.length) return null;
+
+  return (
+    <GlassCard className="shadow-xl">
+      <div className="card-body">
+        <h2 className="card-title text-xl text-base-content">My Teams ({teams.length})</h2>
+
+        <div className="space-y-3 mt-2">
+          {teams.map((team) => (
+            <MyTeamRow key={team._id} team={team} readOnly />
+          ))}
+        </div>
+
+        <div className="mt-4 rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/10 to-secondary/10 p-4 flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary to-secondary text-white flex items-center justify-center flex-shrink-0 shadow-md">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                />
+              </svg>
+            </div>
+            <div className="min-w-0">
+              <p className="font-semibold text-base-content text-sm">Need to make changes?</p>
+              <p className="text-xs text-base-content/60">
+                Edit team name, manager details, or members from your profile.
+              </p>
+            </div>
+          </div>
+          <Button to="/profile" variant="primary" className="flex-shrink-0">
+            Manage Teams
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4 ml-1"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </Button>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/events/TicketPurchaseForm.jsx
+++ b/src/components/events/TicketPurchaseForm.jsx
@@ -1,0 +1,186 @@
+import { useState } from "react";
+import { parseJwt, getAuthToken, fetchWithAuth } from "../../auth/auth";
+import { Button, GlassCard, Spinner } from "../ui";
+
+export default function TicketPurchaseForm({ event, eventId, onTournamentSignup }) {
+  const [quantity, setQuantity] = useState("1");
+  const [email, setEmail] = useState(() => {
+    const token = getAuthToken();
+    if (!token) return "";
+    const payload = parseJwt(token);
+    return payload?.email || "";
+  });
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [buyError, setBuyError] = useState("");
+  const [awaitingConfirm, setAwaitingConfirm] = useState(false);
+
+  const handleBuyTickets = async () => {
+    setBuyError("");
+    setAwaitingConfirm(false);
+
+    if (event.isTournament) {
+      if (!email) {
+        setBuyError("Please enter your email to proceed.");
+        return;
+      }
+      onTournamentSignup(email);
+      return;
+    }
+
+    if (parseInt(quantity) > 5 && !awaitingConfirm) {
+      setAwaitingConfirm(true);
+      return;
+    }
+
+    if (!email) {
+      setBuyError("Please enter your email to proceed.");
+      return;
+    }
+
+    if (!quantity || parseInt(quantity) < 1) {
+      setBuyError("Please select at least 1 ticket.");
+      return;
+    }
+
+    try {
+      setIsProcessing(true);
+      const response = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}payments/create-checkout-session`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            eventId,
+            email,
+            quantity: parseInt(quantity) || 1,
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to create checkout session");
+      }
+
+      window.location.href = data.url;
+    } catch (err) {
+      console.error("Checkout error:", err);
+      setBuyError(err.message || "Something went wrong. Please try again.");
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <GlassCard className="shadow-xl md:sticky md:top-20 hover:shadow-2xl transition-all duration-300">
+      <div className="card-body">
+        <h2 className="card-title text-xl text-base-content">
+          {event.isTournament ? "Team Registration" : "Purchase Tickets"}
+        </h2>
+        <div className="space-y-4">
+          {event.isTournament && (
+            <div className="bg-blue-50 border border-blue-200 rounded-xl p-3 text-xs text-blue-700">
+              The tournament fee is charged <strong>per player</strong>. Spectators and supporters
+              are welcome to attend for free.
+            </div>
+          )}
+          <div>
+            <label className="block text-md font-medium mb-2 text-base-content">Your Email:</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="glass-input"
+              placeholder="Enter your email"
+              required
+            />
+          </div>
+
+          {!event.isTournament && (
+            <div>
+              <label className="block text-md font-medium mb-2 text-base-content">
+                Ticket Quantity:
+              </label>
+              <input
+                type="number"
+                min="1"
+                max={event.ticketsAvailable || 99}
+                value={quantity}
+                onChange={(e) => {
+                  setQuantity(e.target.value);
+                  setAwaitingConfirm(false);
+                }}
+                onBlur={(e) => {
+                  const val = parseInt(e.target.value, 10);
+                  setQuantity(String(isNaN(val) || val < 1 ? 1 : val));
+                }}
+                className="glass-input"
+              />
+              {event.ticketPrice > 0 && (
+                <p className="text-sm text-base-content/70 mt-1">
+                  Total: £{(event.ticketPrice * (parseInt(quantity) || 1)).toFixed(2)}
+                </p>
+              )}
+              {awaitingConfirm && (
+                <div className="mt-3 bg-amber-50 border border-amber-200 rounded-xl p-3">
+                  <p className="text-sm font-medium text-amber-700 mb-2">
+                    You're buying {quantity} tickets — are you sure?
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => {
+                        setAwaitingConfirm(false);
+                        setQuantity(1);
+                      }}
+                      className="flex-1 text-xs py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-100 transition-all cursor-pointer"
+                    >
+                      Change
+                    </button>
+                    <button
+                      onClick={handleBuyTickets}
+                      className="flex-1 text-xs py-1.5 rounded-lg bg-amber-500 text-white hover:bg-amber-600 transition-all font-medium cursor-pointer"
+                    >
+                      Yes, continue
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {buyError && (
+            <p className="text-red-500 text-sm bg-red-50/50 rounded-xl p-2">{buyError}</p>
+          )}
+
+          <div className="pt-2">
+            <Button
+              variant="primary"
+              className="w-full"
+              onClick={handleBuyTickets}
+              disabled={isProcessing || event.ticketsAvailable === 0}
+            >
+              {isProcessing ? (
+                <span className="flex items-center justify-center">
+                  <Spinner size="sm" />
+                  <span className="ml-3">Redirecting to payment...</span>
+                </span>
+              ) : event.ticketsAvailable === 0 ? (
+                "Sold Out"
+              ) : event.isTournament ? (
+                "Register & Pay for Team"
+              ) : (
+                "Buy Tickets"
+              )}
+            </Button>
+          </div>
+
+          {!event.isTournament && (
+            <p className="text-xs text-center text-base-content/50 mt-2">
+              Secure payment via Stripe
+            </p>
+          )}
+        </div>
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/teams/MyTeamRow.jsx
+++ b/src/components/teams/MyTeamRow.jsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import TeamEditForm from "./TeamEditForm";
+
+export default function MyTeamRow({ team, onTeamUpdated, readOnly = false }) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const hasMem = team.members?.length > 0;
+
+  return (
+    <>
+      <div className="bg-white rounded-2xl border border-base-300 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden">
+        <div
+          onClick={() => hasMem && setExpanded((v) => !v)}
+          className={`flex items-center px-5 py-4 gap-4 transition-colors ${hasMem ? "cursor-pointer hover:bg-base-200/30" : ""}`}
+        >
+          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0">
+            <svg
+              className="w-5 h-5 text-primary"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-base-content truncate">{team.name}</p>
+            {team.event?.title && (
+              <p className="text-sm text-base-content/60 truncate mt-0.5">
+                {team.event.title}
+                {team.event.date && (
+                  <span>
+                    {" "}
+                    ·{" "}
+                    {new Date(team.event.date).toLocaleDateString("en-GB", {
+                      day: "numeric",
+                      month: "short",
+                      year: "numeric",
+                    })}
+                  </span>
+                )}
+              </p>
+            )}
+            <p className="text-xs text-base-content/50 mt-0.5">
+              {team.members?.length ?? 0} member{team.members?.length !== 1 ? "s" : ""}
+              {team.manager?.phone && <span> · {team.manager.phone}</span>}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {!readOnly && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditing(true);
+                }}
+                className="btn btn-s bg-base-200/60 hover:bg-base-300/60 border border-base-300/60 text-base-content transition-all duration-300 rounded-lg"
+                title="Edit team"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-8 w-6"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+              </button>
+            )}
+            <span
+              className={`text-xs font-medium px-2.5 py-0.5 rounded-full border ${team.paid ? "bg-green-50 text-green-700 border-green-200" : "bg-orange-50 text-orange-600 border-orange-200"}`}
+            >
+              {team.paid ? "Paid" : "Pending"}
+            </span>
+            {hasMem && (
+              <svg
+                className={`w-4 h-4 text-base-content/50 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            )}
+          </div>
+        </div>
+
+        {hasMem && expanded && (
+          <div className="px-5 pb-4 pt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 border-t border-base-100">
+            {team.members.map((m, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-2.5 bg-base-200/40 rounded-xl px-3 py-2"
+              >
+                <div className="w-6 h-6 rounded-full bg-gradient-to-br from-primary to-primary/70 text-white text-[10px] font-bold flex items-center justify-center flex-shrink-0">
+                  {m.name?.[0]?.toUpperCase() ?? "?"}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-base-content truncate">{m.name}</p>
+                  {m.email && (
+                    <p className="text-[10px] text-base-content/50 truncate">{m.email}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {editing && (
+        <TeamEditForm
+          team={team}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false);
+            onTeamUpdated();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/teams/TeamSignupForm.jsx
+++ b/src/components/teams/TeamSignupForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { getAuthToken } from "../../auth/auth";
+import { fetchWithAuth } from "../../auth/auth";
 import { validatePhone } from "../../util/util";
 import { Button, Spinner } from "../ui";
 
@@ -18,9 +18,7 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
   useEffect(() => {
     if (!managerEmail || !eventId) return;
     setLoadingUnpaid(true);
-    fetch(`${import.meta.env.VITE_DEV_URI}teams/event/${eventId}/unpaid`, {
-      headers: { Authorization: `Bearer ${getAuthToken()}` },
-    })
+    fetchWithAuth(`${import.meta.env.VITE_DEV_URI}teams/event/${eventId}/unpaid`)
       .then((r) => r.json())
       .then((data) => setUnpaidTeams(data.teams || []))
       .catch(() => {})
@@ -31,10 +29,10 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
     setLoading(true);
     setError("");
     try {
-      const paymentRes = await fetch(`${import.meta.env.VITE_DEV_URI}teams/${team._id}/pay`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${getAuthToken()}` },
-      });
+      const paymentRes = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}teams/${team._id}/pay`,
+        { method: "POST" }
+      );
       const paymentData = await paymentRes.json();
       if (!paymentRes.ok || !paymentData.url)
         throw new Error(paymentData.error || "Payment initialization failed");
@@ -65,22 +63,25 @@ export default function TeamSignupForm({ eventId, managerId, onClose }) {
     setLoading(true);
     setError("");
     try {
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}teams/event/${eventId}/signup`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${getAuthToken()}` },
-        body: JSON.stringify({
-          name,
-          members,
-          manager: { name: managerName, email: managerEmail, phone: managerPhone.trim() },
-        }),
-      });
+      const res = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}teams/event/${eventId}/signup`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name,
+            members,
+            manager: { name: managerName, email: managerEmail, phone: managerPhone.trim() },
+          }),
+        }
+      );
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed to register team");
 
-      const paymentRes = await fetch(`${import.meta.env.VITE_DEV_URI}teams/${data.team._id}/pay`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${getAuthToken()}` },
-      });
+      const paymentRes = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}teams/${data.team._id}/pay`,
+        { method: "POST" }
+      );
       const paymentData = await paymentRes.json();
       if (!paymentRes.ok || !paymentData.url)
         throw new Error(paymentData.error || "Payment initialization failed");

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useCallback, useEffect, useState, useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { isAuthenticated, getAuthToken } from "../auth/auth";
+import { isAuthenticated, fetchWithAuth } from "../auth/auth";
 import { optimizeCloudinaryUrl, toSlug } from "../util/util";
 import { Button, Spinner } from "../components/ui";
+import MyTeamRow from "../components/teams/MyTeamRow";
 
 function formatDate(dateStr) {
   if (!dateStr) return "—";
@@ -28,23 +29,26 @@ export default function ProfilePage() {
   const [activeTab, setActiveTab] = useState("Orders");
   const navigate = useNavigate();
 
+  const loadProfile = useCallback(async () => {
+    try {
+      const res = await fetchWithAuth(import.meta.env.VITE_DEV_URI + "users/profile");
+      if (!res.ok) throw new Error("Failed to load profile");
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (!isAuthenticated()) {
       navigate("/login");
       return;
     }
-    const token = getAuthToken();
-    fetch(import.meta.env.VITE_DEV_URI + "users/profile", {
-      headers: { Authorization: "Bearer " + token },
-    })
-      .then(async (res) => {
-        if (!res.ok) throw new Error("Failed to load profile");
-        return res.json();
-      })
-      .then(setData)
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [navigate]);
+    loadProfile();
+  }, [navigate, loadProfile]);
 
   // Group tickets by paymentId so bulk purchases show as one order
   // Hooks must be called before any early returns
@@ -252,7 +256,7 @@ export default function ProfilePage() {
             ) : (
               <div className="space-y-4">
                 {teams.map((team) => (
-                  <TeamRow key={team._id} team={team} />
+                  <MyTeamRow key={team._id} team={team} onTeamUpdated={loadProfile} />
                 ))}
               </div>
             ))}
@@ -428,99 +432,6 @@ function OrderRow({ tickets }) {
   );
 }
 
-function TeamRow({ team }) {
-  const [expanded, setExpanded] = useState(false);
-  const event = team.event;
-
-  return (
-    <div className="bg-white rounded-2xl border border-base-300 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden">
-      <div
-        onClick={() => team.members?.length > 0 && setExpanded((v) => !v)}
-        className={`flex items-center px-5 py-4 gap-4 transition-colors ${team.members?.length > 0 ? "cursor-pointer hover:bg-base-200/30" : ""}`}
-      >
-        {/* Icon */}
-        <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-base-200 to-base-200 flex items-center justify-center flex-shrink-0">
-          <svg
-            className="w-6 h-6 text-base-content/50"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-            />
-          </svg>
-        </div>
-
-        {/* Info */}
-        <div className="flex-1 min-w-0">
-          <p className="font-semibold text-base-content truncate">{team.name}</p>
-          <p className="text-sm text-base-content/50 mt-0.5">
-            {event?.title ?? "Unknown Event"}
-            {event?.date && <span> · {formatDate(event.date)}</span>}
-          </p>
-          {team.manager?.phone && (
-            <p className="text-xs text-base-content/40 mt-0.5">{team.manager.phone}</p>
-          )}
-        </div>
-
-        {/* Right side */}
-        <div className="flex items-center gap-3 flex-shrink-0">
-          <div className="flex flex-col items-end gap-1.5">
-            <span
-              className={`text-xs font-medium px-2.5 py-0.5 rounded-full border ${
-                team.paid
-                  ? "bg-green-50 text-green-700 border-green-200"
-                  : "bg-orange-50 text-orange-600 border-orange-200"
-              }`}
-            >
-              {team.paid ? "✓ Paid" : "Pending"}
-            </span>
-            <span className="text-xs text-base-content/50">
-              {team.members?.length ?? 0} member{team.members?.length !== 1 ? "s" : ""}
-            </span>
-          </div>
-          {team.members?.length > 0 && (
-            <svg
-              className={`w-4 h-4 text-base-content/50 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          )}
-        </div>
-      </div>
-
-      {/* Members list */}
-      {team.members?.length > 0 && expanded && (
-        <div className="px-5 pb-4 pt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 border-t border-base-100">
-          {team.members.map((m, i) => (
-            <div key={i} className="flex items-center gap-2.5 bg-base-200/40 rounded-xl px-3 py-2">
-              <div className="w-6 h-6 rounded-full bg-gradient-to-br from-primary to-primary/70 text-white text-[10px] font-bold flex items-center justify-center flex-shrink-0">
-                {m.name?.[0]?.toUpperCase() ?? "?"}
-              </div>
-              <div className="min-w-0">
-                <p className="text-xs font-medium text-base-content truncate">{m.name}</p>
-                {m.email && <p className="text-[10px] text-base-content/50 truncate">{m.email}</p>}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 const CATEGORY_COLORS = {
   Language: "from-blue-500 to-primary/70",
   Religious: "from-emerald-500 to-teal-600",
@@ -562,10 +473,9 @@ function EnrollmentRow({ enrollment }) {
         setConfirm(null);
         setCancelling(true);
         try {
-          const token = getAuthToken();
-          const res = await fetch(
+          const res = await fetchWithAuth(
             `${import.meta.env.VITE_DEV_URI}courses/enrollments/${enrollment._id}/cancel`,
-            { method: "POST", headers: { Authorization: "Bearer " + token } }
+            { method: "POST" }
           );
           const data = await res.json();
           if (res.ok) setCancelDone(true);
@@ -581,10 +491,9 @@ function EnrollmentRow({ enrollment }) {
   const handleReactivate = async () => {
     setReactivating(true);
     try {
-      const token = getAuthToken();
-      const res = await fetch(
+      const res = await fetchWithAuth(
         `${import.meta.env.VITE_DEV_URI}courses/enrollments/${enrollment._id}/reactivate`,
-        { method: "POST", headers: { Authorization: "Bearer " + token } }
+        { method: "POST" }
       );
       const data = await res.json();
       if (res.ok) {
@@ -613,15 +522,11 @@ function EnrollmentRow({ enrollment }) {
         setConfirm(null);
         setRemovingIdx(index);
         try {
-          const token = getAuthToken();
-          const res = await fetch(
+          const res = await fetchWithAuth(
             `${import.meta.env.VITE_DEV_URI}courses/enrollments/${enrollment._id}/remove-participant`,
             {
               method: "POST",
-              headers: {
-                Authorization: "Bearer " + token,
-                "Content-Type": "application/json",
-              },
+              headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ participantIndex: index }),
             }
           );

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -12,7 +12,7 @@ import {
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
-import { getAuthToken, getUserRole as getAuthRole } from "../../auth/auth";
+import { getAuthToken, getUserRole as getAuthRole, fetchWithAuth } from "../../auth/auth";
 import { PageContainer, Spinner } from "../../components/ui";
 import { roleBadgeClass } from "../../components/admin/adminHelpers";
 import TicketsTab from "../../components/admin/TicketsTab";
@@ -51,10 +51,7 @@ export default function AdminDashboard() {
       return;
     }
 
-    const token = getAuthToken();
-    fetch(import.meta.env.VITE_DEV_URI + "admin/dashboard", {
-      headers: { Authorization: "Bearer " + token },
-    })
+    fetchWithAuth(import.meta.env.VITE_DEV_URI + "admin/dashboard")
       .then(async (res) => {
         if (!res.ok) throw new Error("Failed to load dashboard");
         return res.json();

--- a/src/pages/content/About.jsx
+++ b/src/pages/content/About.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
-import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
+import { isAdmin, isModerator, fetchWithAuth } from "../../auth/auth";
 import { compressImage } from "../../util/compressImage";
-import { Link } from "react-router-dom";
 import ConfirmModal from "../../components/common/ConfirmModal";
+import { Button } from "../../components/ui";
 
 const DEFAULT_CARDS = [
   {
@@ -144,16 +144,12 @@ export default function About() {
     setResetting(true);
     setSaveError(null);
     try {
-      const token = getAuthToken();
       const url =
         section === "all"
           ? `${import.meta.env.VITE_DEV_URI}pageContent/about`
           : `${import.meta.env.VITE_DEV_URI}pageContent/about/${section}`;
 
-      const res = await fetch(url, {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await fetchWithAuth(url, { method: "DELETE" });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.message || `Server error (${res.status})`);
@@ -215,7 +211,6 @@ export default function About() {
 
     setSaving(true);
     try {
-      const token = getAuthToken();
       const formData = new FormData();
       formData.append(
         "contentData",
@@ -233,9 +228,8 @@ export default function About() {
         formData.append(`activityImage_${index}`, file);
       });
 
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}pageContent/about`, {
+      const res = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}pageContent/about`, {
         method: "PUT",
-        headers: { Authorization: `Bearer ${token}` },
         body: formData,
       });
       if (!res.ok) {
@@ -525,13 +519,18 @@ export default function About() {
               value={draft.getInvolvedText}
               onChange={(e) => setDraft({ ...draft, getInvolvedText: e.target.value })}
             />
-            <button
-              onClick={() => resetSection("getInvolved")}
-              disabled={resetting}
-              className="mb-4 px-3 py-1.5 rounded-full bg-white border border-amber-300 text-amber-700 text-xs font-medium shadow hover:bg-amber-50 transition-all disabled:opacity-60 cursor-pointer"
-            >
-              Reset to Defaults
-            </button>
+            <div className="flex gap-3 justify-center">
+              <Button
+                variant="danger"
+                onClick={() => resetSection("getInvolved")}
+                disabled={resetting}
+              >
+                Reset to Defaults
+              </Button>
+              <Button variant="primary" disabled>
+                Contact Us
+              </Button>
+            </div>
           </>
         ) : (
           <>
@@ -539,14 +538,11 @@ export default function About() {
               {pageContent.getInvolvedTitle}
             </h2>
             <p className="text-lg text-base-content/80 mb-6">{pageContent.getInvolvedText}</p>
+            <Button variant="primary" to="/contact">
+              Contact Us
+            </Button>
           </>
         )}
-        <Link
-          to="/contact"
-          className="inline-block bg-gradient-to-r from-primary to-secondary text-white px-6 py-3 rounded-full font-semibold shadow-primary/20 transition-all"
-        >
-          Contact Us
-        </Link>
       </div>
     </div>
   );

--- a/src/pages/content/Home.jsx
+++ b/src/pages/content/Home.jsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect, useRef } from "react";
 import { Link, useRouteLoaderData } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import EventCard from "../../components/events/EventCard";
+import CourseCard from "../../components/courses/CourseCard";
 import Button from "../../components/ui/Button";
-import { isAdmin, isModerator, getAuthToken } from "../../auth/auth";
+import { isAdmin, isModerator, fetchWithAuth } from "../../auth/auth";
 import { compressImage } from "../../util/compressImage";
 import ConfirmModal from "../../components/common/ConfirmModal";
 
@@ -20,7 +21,7 @@ function mergeWithDefaults(saved) {
 }
 
 export default function Home() {
-  const { events } = useRouteLoaderData("root");
+  const { events, courses } = useRouteLoaderData("root");
   const canEdit = isAdmin() || isModerator();
 
   const [pageContent, setPageContent] = useState(DEFAULTS);
@@ -69,10 +70,8 @@ export default function Home() {
     setResetting(true);
     setSaveError(null);
     try {
-      const token = getAuthToken();
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}pageContent/home`, {
+      const res = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}pageContent/home`, {
         method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
@@ -105,7 +104,6 @@ export default function Home() {
 
     setSaving(true);
     try {
-      const token = getAuthToken();
       const formData = new FormData();
       formData.append(
         "contentData",
@@ -117,9 +115,8 @@ export default function Home() {
       );
       if (heroImageFile) formData.append("heroImage", heroImageFile);
 
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}pageContent/home`, {
+      const res = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}pageContent/home`, {
         method: "PUT",
-        headers: { Authorization: `Bearer ${token}` },
         body: formData,
       });
       if (!res.ok) {
@@ -140,6 +137,7 @@ export default function Home() {
   };
 
   const upcomingEvents = events.filter((e) => new Date(e.date) >= new Date());
+  const availableCourses = (courses || []).filter((c) => c.enrollmentOpen).slice(0, 3);
   const heroImage = heroImagePreview || pageContent.heroImage;
 
   return (
@@ -395,6 +393,46 @@ export default function Home() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {upcomingEvents?.map((event) => (
               <EventCard key={event._id} event={event} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ── Available Courses ── */}
+      <div className="container mx-auto p-6">
+        <div className="flex items-center justify-between mb-8">
+          <h2 className="text-3xl font-bold text-base-content">Available Courses</h2>
+          <Link
+            to="/courses"
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-gradient-to-r from-primary to-secondary text-white text-sm font-semibold shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
+            </svg>
+            View All Courses
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 7l5 5m0 0l-5 5m5-5H6"
+              />
+            </svg>
+          </Link>
+        </div>
+        {availableCourses.length === 0 ? (
+          <div className="glass-card p-8 text-center rounded-xl backdrop-blur-md shadow-xl">
+            <p className="text-base-content/70">No courses available right now.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {availableCourses.map((course) => (
+              <CourseCard key={course._id} course={course} />
             ))}
           </div>
         )}

--- a/src/pages/courses/CourseConfirmation.jsx
+++ b/src/pages/courses/CourseConfirmation.jsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+import { Button } from "../../components/ui";
 
 export default function CourseConfirmation() {
   const [searchParams] = useSearchParams();
@@ -98,18 +99,26 @@ export default function CourseConfirmation() {
         </div>
 
         <div className="flex flex-col sm:flex-row gap-3">
-          <Link
-            to="/profile"
-            className="flex-1 btn bg-gradient-to-r from-primary to-secondary border-none text-white transition-all rounded-xl shadow-md"
-          >
+          <Button variant="primary" to="/profile" className="flex-1">
             View My Profile
-          </Link>
-          <Link
-            to="/courses"
-            className="flex-1 btn bg-white/60 border border-base-300 text-base-content hover:bg-white/80 rounded-xl"
-          >
+          </Button>
+          <Button variant="secondary" to="/courses" className="flex-1">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
             Back to Courses
-          </Link>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/pages/courses/CourseDetails.jsx
+++ b/src/pages/courses/CourseDetails.jsx
@@ -2,9 +2,10 @@ import React, { useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getAuthToken, isAuthenticated, parseJwt, isAdmin, isModerator } from "../../auth/auth";
+import { getAuthToken, isAuthenticated, parseJwt, fetchWithAuth } from "../../auth/auth";
 import { slugToId, validatePhone } from "../../util/util";
-import { PageContainer, Button, GlassCard } from "../../components/ui";
+import { PageContainer, Button, GlassCard, Spinner } from "../../components/ui";
+import EnrolledPanel from "../../components/courses/EnrolledPanel";
 
 const INTERVAL_LABELS = { month: "month", year: "year" };
 const INTERVAL_ADJ = { month: "Monthly", year: "Yearly" };
@@ -15,20 +16,6 @@ const CATEGORY_COLORS = {
   Academic: "from-primary to-secondary",
   Arts: "from-secondary to-primary",
   Other: "from-warning to-warning/70",
-};
-
-const STATUS_STYLES = {
-  active: "bg-green-100 text-green-700",
-  paid: "bg-blue-100 text-blue-700",
-  free: "bg-teal-100 text-teal-700",
-  past_due: "bg-amber-100 text-amber-700",
-};
-
-const STATUS_LABELS = {
-  active: "Active Subscription",
-  paid: "Enrolled",
-  free: "Enrolled (Free)",
-  past_due: "Past Due",
 };
 
 export default function CourseDetails() {
@@ -48,16 +35,6 @@ export default function CourseDetails() {
   const [multiMode, setMultiMode] = useState(false);
   const [participants, setParticipants] = useState([{ name: "", age: "", email: "" }]);
 
-  // Add-participant form state
-  const [newParticipant, setNewParticipant] = useState({ name: "", age: "", email: "" });
-  const [addingParticipant, setAddingParticipant] = useState(false);
-  const [addParticipantError, setAddParticipantError] = useState("");
-
-  // Cancel / reactivate state
-  const [cancellingSubscription, setCancellingSubscription] = useState(false);
-  const [reactivatingSubscription, setReactivatingSubscription] = useState(false);
-  const [subscriptionError, setSubscriptionError] = useState("");
-
   const addParticipant = () => setParticipants((p) => [...p, { name: "", age: "", email: "" }]);
   const removeParticipant = (i) => setParticipants((p) => p.filter((_, idx) => idx !== i));
   const updateParticipant = (i, field, value) =>
@@ -66,7 +43,6 @@ export default function CourseDetails() {
       updated[i] = { ...updated[i], [field]: value };
       return updated;
     });
-  const canManage = isAdmin() || isModerator();
 
   const {
     data: course,
@@ -84,9 +60,9 @@ export default function CourseDetails() {
   const { data: enrollmentData } = useQuery({
     queryKey: ["my-enrollment", courseId],
     queryFn: async () => {
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}courses/${courseId}/my-enrollment`, {
-        headers: { Authorization: `Bearer ${getAuthToken()}` },
-      });
+      const res = await fetchWithAuth(
+        `${import.meta.env.VITE_DEV_URI}courses/${courseId}/my-enrollment`
+      );
       if (!res.ok) return { enrollment: null };
       return res.json();
     },
@@ -94,77 +70,6 @@ export default function CourseDetails() {
   });
 
   const myEnrollment = enrollmentData?.enrollment;
-
-  const handleAddParticipant = async () => {
-    setAddParticipantError("");
-    if (!newParticipant.name.trim()) {
-      setAddParticipantError("Name is required.");
-      return;
-    }
-    try {
-      setAddingParticipant(true);
-      const res = await fetch(
-        `${import.meta.env.VITE_DEV_URI}courses/enrollments/${myEnrollment._id}/add-participant`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${getAuthToken()}`,
-          },
-          body: JSON.stringify(newParticipant),
-        }
-      );
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Failed to add participant");
-      setNewParticipant({ name: "", age: "", email: "" });
-      queryClient.invalidateQueries({ queryKey: ["my-enrollment", courseId] });
-    } catch (err) {
-      setAddParticipantError(err.message);
-    } finally {
-      setAddingParticipant(false);
-    }
-  };
-
-  const handleCancelSubscription = async () => {
-    setSubscriptionError("");
-    setCancellingSubscription(true);
-    try {
-      const res = await fetch(
-        `${import.meta.env.VITE_DEV_URI}courses/enrollments/${myEnrollment._id}/cancel`,
-        { method: "POST", headers: { Authorization: `Bearer ${getAuthToken()}` } }
-      );
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Failed to cancel subscription");
-      queryClient.invalidateQueries({ queryKey: ["my-enrollment", courseId] });
-    } catch (err) {
-      setSubscriptionError(err.message);
-    } finally {
-      setCancellingSubscription(false);
-    }
-  };
-
-  const handleReactivateSubscription = async () => {
-    setSubscriptionError("");
-    setReactivatingSubscription(true);
-    try {
-      const res = await fetch(
-        `${import.meta.env.VITE_DEV_URI}courses/enrollments/${myEnrollment._id}/reactivate`,
-        { method: "POST", headers: { Authorization: `Bearer ${getAuthToken()}` } }
-      );
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Failed to reactivate subscription");
-      if (data.url) {
-        // Stripe subscription was gone — redirect to new checkout
-        window.location.href = data.url;
-        return;
-      }
-      queryClient.invalidateQueries({ queryKey: ["my-enrollment", courseId] });
-    } catch (err) {
-      setSubscriptionError(err.message);
-    } finally {
-      setReactivatingSubscription(false);
-    }
-  };
 
   const handleEnroll = async () => {
     setEnrollError("");
@@ -191,9 +96,9 @@ export default function CourseDetails() {
         return;
       }
 
-      const res = await fetch(`${import.meta.env.VITE_DEV_URI}courses/${courseId}/enroll`, {
+      const res = await fetchWithAuth(`${import.meta.env.VITE_DEV_URI}courses/${courseId}/enroll`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${getAuthToken()}` },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, phone: phone.trim(), participants: enrollParticipants }),
       });
       const data = await res.json();
@@ -210,8 +115,23 @@ export default function CourseDetails() {
     }
   };
 
-  if (isLoading) return <p className="text-center text-base-content/50 mt-20">Loading...</p>;
-  if (error) return <p className="text-center text-red-500 mt-20">Error: {error.message}</p>;
+  if (isLoading)
+    return (
+      <PageContainer center>
+        <div className="flex flex-col items-center gap-3">
+          <Spinner />
+          <p className="text-sm text-base-content/50">Loading course details...</p>
+        </div>
+      </PageContainer>
+    );
+  if (error)
+    return (
+      <PageContainer center>
+        <div className="bg-white/90 backdrop-blur-md rounded-2xl p-8 shadow-xl border border-red-100 text-center max-w-sm">
+          <p className="text-red-500 font-medium mb-4">{error.message}</p>
+        </div>
+      </PageContainer>
+    );
 
   const gradient = CATEGORY_COLORS[course.category] || CATEGORY_COLORS.Other;
   const spotsLeft = course.maxEnrollment ? course.maxEnrollment - course.currentEnrollment : null;
@@ -238,17 +158,17 @@ export default function CourseDetails() {
       </div>
 
       <div className="container mx-auto p-6">
-        {canManage && (
-          <div className="flex gap-3 mb-6">
-            <Button variant="primary" to={`/courses/${courseSlug}/edit`}>
-              Edit Course
-            </Button>
-          </div>
+        {course.images && course.images.length > 0 && (
+          <img
+            src={course.images[0]}
+            alt={course.title}
+            className="w-full aspect-[16/9] object-cover rounded-2xl shadow-xl mb-6"
+          />
         )}
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {/* Left — details */}
-          <div className="md:col-span-2 space-y-6">
+          {/* Left — details (second on mobile) */}
+          <div className="md:col-span-2 md:order-1 space-y-6">
             <GlassCard className="p-6">
               <h2 className="text-xl font-bold text-base-content mb-4">Course Details</h2>
               <div className="space-y-3">
@@ -383,201 +303,24 @@ export default function CourseDetails() {
                 )}
               </div>
             </GlassCard>
-            {course.images && course.images.length > 0 && (
-              <img
-                src={course.images[0]}
-                alt={course.title}
-                className="w-full h-3/8  object-cover rounded-2xl shadow-xl"
-              />
-            )}
             <GlassCard className="p-6">
               <h2 className="text-xl font-bold text-base-content mb-3">About This Course</h2>
               <p className="text-base-content/80 leading-relaxed">{course.description}</p>
             </GlassCard>
           </div>
 
-          {/* Right — enrollment */}
-          <div className="md:col-span-1">
+          {/* Right — enrollment (first on mobile) */}
+          <div className="md:col-span-1 md:order-2">
             <GlassCard className="md:sticky md:top-20">
               <div className="p-6">
                 {myEnrollment ? (
-                  /* ── Already enrolled ── */
-                  <div className="space-y-4">
-                    <div className="flex items-center gap-2 mb-2">
-                      <div className="w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
-                        <svg
-                          className="w-5 h-5 text-green-600"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2.5}
-                            d="M5 13l4 4L19 7"
-                          />
-                        </svg>
-                      </div>
-                      <h2 className="text-xl font-bold text-base-content">You're Enrolled</h2>
-                    </div>
-
-                    <span
-                      className={`inline-block text-xs font-semibold px-3 py-1 rounded-full ${
-                        myEnrollment.subscriptionStatus === "cancelled"
-                          ? "bg-orange-100 text-orange-700"
-                          : STATUS_STYLES[myEnrollment.status] || "bg-base-200 text-base-content"
-                      }`}
-                    >
-                      {myEnrollment.subscriptionStatus === "cancelled"
-                        ? "Cancelled"
-                        : STATUS_LABELS[myEnrollment.status] || myEnrollment.status}
-                    </span>
-
-                    {myEnrollment.subscriptionId &&
-                      myEnrollment.subscriptionStatus === "cancelled" && (
-                        <div className="bg-orange-50 border border-orange-200 rounded-xl p-3 text-xs text-orange-700">
-                          <p className="font-semibold mb-1">You have cancelled your subscription</p>
-                          <p>You'll retain access until the end of your current billing period.</p>
-                          {myEnrollment.currentPeriodEnd && (
-                            <p className="mt-1 font-medium text-orange-600">
-                              Access until{" "}
-                              {new Date(myEnrollment.currentPeriodEnd).toLocaleDateString("en-GB", {
-                                day: "numeric",
-                                month: "short",
-                                year: "numeric",
-                              })}
-                            </p>
-                          )}
-                        </div>
-                      )}
-
-                    {myEnrollment.subscriptionId &&
-                      myEnrollment.subscriptionStatus !== "cancelled" && (
-                        <div className="bg-blue-50 border border-blue-200 rounded-xl p-3 text-xs text-blue-700">
-                          <p className="font-semibold mb-1">
-                            {INTERVAL_ADJ[course.billingInterval] || "Monthly"} Subscription
-                          </p>
-                          <p>
-                            £{course.price} / {INTERVAL_LABELS[course.billingInterval] || "month"}
-                          </p>
-                          {myEnrollment.currentPeriodEnd && (
-                            <p className="mt-1 text-blue-600">
-                              Renews{" "}
-                              {new Date(myEnrollment.currentPeriodEnd).toLocaleDateString("en-GB", {
-                                day: "numeric",
-                                month: "short",
-                                year: "numeric",
-                              })}
-                            </p>
-                          )}
-                        </div>
-                      )}
-
-                    {/* Current participants */}
-                    <div>
-                      <p className="text-sm font-semibold text-base-content mb-2">
-                        Participants ({myEnrollment.participants?.length || 0})
-                      </p>
-                      <div className="space-y-1.5">
-                        {myEnrollment.participants?.map((p, i) => (
-                          <div
-                            key={i}
-                            className="flex items-center gap-2 bg-base-200/50 rounded-lg px-3 py-2 text-sm"
-                          >
-                            <div className="w-6 h-6 rounded-full bg-gradient-to-br from-primary to-secondary flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
-                              {p.name.charAt(0).toUpperCase()}
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <p className="font-medium text-base-content truncate">{p.name}</p>
-                              {p.age && <p className="text-xs text-base-content/50">Age {p.age}</p>}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-
-                    {/* Add participant form */}
-                    {myEnrollment.status !== "cancelled" &&
-                      myEnrollment.subscriptionStatus !== "cancelled" && (
-                        <div className="border-t border-base-300/50 pt-4">
-                          <p className="text-sm font-semibold text-base-content mb-2">
-                            Add Participant
-                          </p>
-                          <div className="space-y-2">
-                            <input
-                              type="text"
-                              placeholder="Name *"
-                              value={newParticipant.name}
-                              onChange={(e) =>
-                                setNewParticipant((p) => ({ ...p, name: e.target.value }))
-                              }
-                              className="glass-input text-sm py-1.5"
-                            />
-                            <input
-                              type="number"
-                              placeholder="Age"
-                              min="1"
-                              value={newParticipant.age}
-                              onChange={(e) =>
-                                setNewParticipant((p) => ({ ...p, age: e.target.value }))
-                              }
-                              className="glass-input text-sm py-1.5"
-                            />
-                            {addParticipantError && (
-                              <p className="text-red-500 text-xs">{addParticipantError}</p>
-                            )}
-                            <Button
-                              variant="primary"
-                              onClick={handleAddParticipant}
-                              disabled={addingParticipant}
-                              className="w-full text-sm"
-                            >
-                              {addingParticipant ? "Adding..." : "+ Add Participant"}
-                            </Button>
-                            {course.isSubscription && (
-                              <p className="text-xs text-base-content/50 text-center">
-                                Adding a participant will increase your subscription billing.
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                      )}
-
-                    {/* Cancel / Reactivate subscription */}
-                    {myEnrollment.subscriptionId && (
-                      <div className="border-t border-base-300/50 pt-4 space-y-2">
-                        {myEnrollment.subscriptionStatus === "cancelled" ? (
-                          <Button
-                            variant="primary"
-                            onClick={handleReactivateSubscription}
-                            disabled={reactivatingSubscription}
-                            className="w-full text-sm"
-                          >
-                            {reactivatingSubscription
-                              ? "Reactivating..."
-                              : "Reactivate Subscription"}
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="danger"
-                            onClick={handleCancelSubscription}
-                            disabled={cancellingSubscription}
-                            className="w-full text-sm"
-                          >
-                            {cancellingSubscription ? "Cancelling..." : "Cancel Subscription"}
-                          </Button>
-                        )}
-                        {subscriptionError && (
-                          <p className="text-red-500 text-xs text-center">{subscriptionError}</p>
-                        )}
-                      </div>
-                    )}
-
-                    <Button variant="ghost" to="/profile" className="w-full text-sm">
-                      Manage in Profile
-                    </Button>
-                  </div>
+                  <EnrolledPanel
+                    course={course}
+                    enrollment={myEnrollment}
+                    onChanged={() =>
+                      queryClient.invalidateQueries({ queryKey: ["my-enrollment", courseId] })
+                    }
+                  />
                 ) : (
                   /* ── Not enrolled — enroll form ── */
                   <>
@@ -812,9 +555,15 @@ export default function CourseDetails() {
           </div>
         </div>
 
-        <div className="mt-8">
-          <Button variant="ghost" onClick={() => navigate(-1)}>
-            <svg className="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <div className="mt-8 mb-4 flex items-center justify-between gap-3 flex-wrap">
+          <Button variant="secondary" onClick={() => navigate(-1)}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -824,6 +573,25 @@ export default function CourseDetails() {
             </svg>
             Back to Courses
           </Button>
+          <button
+            onClick={() =>
+              window.open("https://www.facebook.com/profile.php?id=100081705505202", "_blank")
+            }
+            className="btn bg-[#1877F2] hover:bg-[#166FE5] text-white border-none shadow-md hover:shadow-lg transition-all duration-200"
+            aria-label="Share on Facebook"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="mr-1.5"
+            >
+              <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z" />
+            </svg>
+            Share on Facebook
+          </button>
         </div>
       </div>
     </PageContainer>

--- a/src/pages/courses/CourseRoot.jsx
+++ b/src/pages/courses/CourseRoot.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import CourseHeader from "../../components/courses/CourseHeader";
+
+const CourseRoot = () => {
+  return (
+    <>
+      <CourseHeader />
+      <Outlet />
+    </>
+  );
+};
+
+export default CourseRoot;

--- a/src/pages/courses/Courses.jsx
+++ b/src/pages/courses/Courses.jsx
@@ -81,15 +81,15 @@ export default function CoursesPage() {
               className="glass-input pl-9 py-2.5"
             />
           </div>
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex bg-white/60 rounded-xl border border-white/40 p-1 flex-wrap">
             {CATEGORIES.map((cat) => (
               <button
                 key={cat}
                 onClick={() => setActiveCategory(cat)}
-                className={`px-3 py-2 rounded-xl text-sm font-medium transition-all ${
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer ${
                   activeCategory === cat
                     ? "bg-gradient-to-r from-primary to-secondary text-white shadow-md"
-                    : "bg-white/60 text-base-content hover:bg-white/80 border border-base-300"
+                    : "text-base-content hover:bg-white/80"
                 }`}
               >
                 {cat}

--- a/src/pages/events/Event.jsx
+++ b/src/pages/events/Event.jsx
@@ -142,7 +142,7 @@ export default function EventPage() {
           {/* Search + Sort (cards view only) */}
           {view === "cards" && (
             <div className="flex items-center gap-2 flex-1">
-              <div className="relative max-w-xs flex-1">
+              <div className="relative flex-1">
                 <svg
                   className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/50"
                   fill="none"

--- a/src/pages/events/EventDetails.jsx
+++ b/src/pages/events/EventDetails.jsx
@@ -1,28 +1,22 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useParams, useNavigate, ScrollRestoration } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import TeamSignupForm from "../../components/teams/TeamSignupForm";
-import TeamEditForm from "../../components/teams/TeamEditForm";
-import { parseJwt, getAuthToken, fetchWithAuth, isAuthenticated } from "../../auth/auth";
+import { fetchWithAuth, isAuthenticated } from "../../auth/auth";
 import { slugToId } from "../../util/util";
 import { Button, PageContainer, GlassCard, Spinner } from "../../components/ui";
+import EventDetailsBanner from "../../components/events/EventDetailsBanner";
+import EventInfoGrid from "../../components/events/EventInfoGrid";
+import TicketPurchaseForm from "../../components/events/TicketPurchaseForm";
+import MyTeamsSection from "../../components/events/MyTeamsSection";
 
 export default function EventDetails() {
   const { eventSlug } = useParams();
   const eventId = slugToId(eventSlug);
   const navigate = useNavigate();
-  const [quantity, setQuantity] = useState("1");
-  const [email, setEmail] = useState(() => {
-    const token = getAuthToken();
-    if (!token) return "";
-    const payload = parseJwt(token);
-    return payload?.email || "";
-  });
   const [showTeamSignup, setShowTeamSignup] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
-  const [buyError, setBuyError] = useState("");
-  const [awaitingConfirm, setAwaitingConfirm] = useState(false);
+  const [tournamentEmail, setTournamentEmail] = useState("");
 
   const queryClient = useQueryClient();
   const loggedIn = isAuthenticated();
@@ -60,67 +54,13 @@ export default function EventDetails() {
     enabled: !!isTournament && loggedIn,
   });
 
-  // ─── Stripe Checkout ──────────────────────────────────────────────────────
-  const handleBuyTickets = async () => {
-    setBuyError("");
-    setAwaitingConfirm(false);
-
-    if (isTournament) {
-      if (!email) {
-        setBuyError("Please enter your email to proceed.");
-        return;
-      }
-      setShowTeamSignup(true);
-      return;
-    }
-
-    if (parseInt(quantity) > 5 && !awaitingConfirm) {
-      setAwaitingConfirm(true);
-      return;
-    }
-
-    if (!email) {
-      setBuyError("Please enter your email to proceed.");
-      return;
-    }
-
-    if (!quantity || parseInt(quantity) < 1) {
-      setBuyError("Please select at least 1 ticket.");
-      return;
-    }
-
-    try {
-      setIsProcessing(true);
-      const response = await fetchWithAuth(
-        `${import.meta.env.VITE_DEV_URI}payments/create-checkout-session`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            eventId,
-            email,
-            quantity: parseInt(quantity) || 1,
-          }),
-        }
-      );
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to create checkout session");
-      }
-
-      // Redirect to Stripe's hosted checkout page
-      window.location.href = data.url;
-    } catch (err) {
-      console.error("Checkout error:", err);
-      setBuyError(err.message || "Something went wrong. Please try again.");
-      setIsProcessing(false);
-    }
-  };
-
   const handleShare = () => {
     window.open(`https://www.facebook.com/profile.php?id=100081705505202`, "_blank");
+  };
+
+  const handleTournamentSignup = (email) => {
+    setTournamentEmail(email);
+    setShowTeamSignup(true);
   };
 
   if (isLoading)
@@ -155,222 +95,21 @@ export default function EventDetails() {
           content={event.shortDescription || event.longDescription?.slice(0, 155)}
         />
       </Helmet>
-      {/* Header Banner */}
-      <div className="bg-gradient-to-r from-primary to-secondary text-white p-6 md:p-12 shadow-lg backdrop-blur-sm">
-        <div className="container mx-auto">
-          <h1 className="text-3xl md:text-5xl font-bold text-center mb-2">{event.title}</h1>
-          {event.organizer && (
-            <p className="text-center text-lg">
-              <span className="flex items-center justify-center">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-5 w-5 mr-2"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                  />
-                </svg>
-                {event.organizer}
-              </span>
-            </p>
-          )}
-        </div>
-      </div>
+
+      <EventDetailsBanner event={event} />
 
       <div className="container mx-auto p-4">
-        {/* Social Share */}
-        <div className="flex justify-end gap-2 mb-6">
-          <Button
-            variant="circle"
-            onClick={handleShare}
-            className="bg-gradient-to-br from-primary to-secondary text-white hover:scale-110 border-none shadow-md"
-            aria-label="Share on Facebook"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-            >
-              <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z" />
-            </svg>
-          </Button>
-        </div>
+        {event.images && event.images.length > 0 && (
+          <img
+            src={event.images[0]}
+            alt={event.title}
+            className="w-full aspect-[16/9] object-cover rounded-2xl shadow-xl mb-6"
+          />
+        )}
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {/* Left column: Event Details */}
-          <div className="md:col-span-2 space-y-6">
-            <GlassCard className="shadow-xl">
-              <div className="card-body">
-                <h2 className="card-title text-xl text-base-content">Event Details:</h2>
-                <div className="space-y-4">
-                  <div className="flex items-start">
-                    <div className="bg-gradient-to-br from-primary to-secondary text-white p-3 rounded-xl mr-4 shadow-md">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-6 w-6"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <h3 className="font-bold text-lg text-base-content">Date & Time</h3>
-                      <p className="text-base-content/70">
-                        {new Date(event.date).toLocaleDateString()}, {event.openingTime}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex items-start">
-                    <div className="bg-gradient-to-br from-primary to-secondary text-white p-3 rounded-xl mr-4 shadow-md">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-6 w-6"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                        />
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <h3 className="font-bold text-lg text-base-content">Location</h3>
-                      <p className="text-base-content/70">
-                        {event.street}, {event.city}, {event.postCode}
-                      </p>
-                    </div>
-                  </div>
-
-                  {event.ticketPrice > 0 && (
-                    <div className="flex items-start">
-                      <div className="bg-gradient-to-br from-secondary to-primary text-white p-3 rounded-xl mr-4 shadow-md">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-6 w-6"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"
-                          />
-                        </svg>
-                      </div>
-                      <div>
-                        <h3 className="font-bold text-lg text-base-content">
-                          {event.isTournament ? "Tournament Fee" : "Ticket Price"}
-                        </h3>
-                        <p className="text-base-content/70">£{event.ticketPrice}</p>
-                        {event.isTournament && (
-                          <p className="text-xs text-base-content/50 mt-0.5">
-                            Per player — spectators enter free
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  )}
-
-                  {event.ticketsAvailable !== undefined && (
-                    <div className="flex items-start">
-                      <div className="bg-gradient-to-br from-green-500 to-teal-600 text-white p-3 rounded-xl mr-4 shadow-md">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-6 w-6"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-                          />
-                        </svg>
-                      </div>
-                      <div>
-                        <h3 className="font-bold text-lg text-base-content">Availability</h3>
-                        <p className="text-base-content/70">
-                          {event.ticketsAvailable > 0
-                            ? `${event.ticketsAvailable} tickets remaining`
-                            : "Sold out"}
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </GlassCard>
-            {event.images && event.images.length > 0 && (
-              <img
-                src={event.images[0]}
-                alt={event.title}
-                className="w-full h-3/8 object-cover rounded-2xl shadow-xl"
-              />
-            )}
-            <GlassCard className="shadow-xl">
-              <div className="card-body">
-                <h2 className="card-title text-xl text-base-content">About This Event</h2>
-                <div className="prose max-w-none text-base-content/80">
-                  <p>{event.longDescription}</p>
-                </div>
-              </div>
-            </GlassCard>
-
-            {/* My Teams */}
-            {isTournament && myTeams.length > 0 && (
-              <GlassCard className="shadow-xl">
-                <div className="card-body">
-                  <h2 className="card-title text-xl text-base-content">
-                    My Teams ({myTeams.length})
-                  </h2>
-                  <div className="space-y-3 mt-2">
-                    {myTeams.map((team) => (
-                      <MyTeamRow
-                        key={team._id}
-                        team={team}
-                        onTeamUpdated={() =>
-                          queryClient.invalidateQueries({ queryKey: ["my-teams", eventId] })
-                        }
-                      />
-                    ))}
-                  </div>
-                </div>
-              </GlassCard>
-            )}
-          </div>
-
-          {/* Right column: Ticket Purchase */}
-          <div className="md:col-span-1">
+          {/* Right column on desktop, first on mobile: Ticket Purchase */}
+          <div className="md:col-span-1 md:order-2">
             {!isEventInPast && event.ticketPrice === 0 && !event.isTournament ? (
               <GlassCard className="shadow-xl">
                 <div className="card-body text-center">
@@ -396,119 +135,11 @@ export default function EventDetails() {
                 </div>
               </GlassCard>
             ) : !isEventInPast ? (
-              <GlassCard className="shadow-xl md:sticky md:top-20 hover:shadow-2xl transition-all duration-300">
-                <div className="card-body">
-                  <h2 className="card-title text-xl text-base-content">
-                    {event.isTournament ? "Team Registration" : "Purchase Tickets"}
-                  </h2>
-                  <div className="space-y-4">
-                    {event.isTournament && (
-                      <div className="bg-blue-50 border border-blue-200 rounded-xl p-3 text-xs text-blue-700">
-                        The tournament fee is charged <strong>per player</strong>. Spectators and
-                        supporters are welcome to attend for free.
-                      </div>
-                    )}
-                    <div>
-                      <label className="block text-md font-medium mb-2 text-base-content">
-                        Your Email:
-                      </label>
-                      <input
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        className="glass-input"
-                        placeholder="Enter your email"
-                        required
-                      />
-                    </div>
-
-                    {!event.isTournament && (
-                      <div>
-                        <label className="block text-md font-medium mb-2 text-base-content">
-                          Ticket Quantity:
-                        </label>
-                        <input
-                          type="number"
-                          min="1"
-                          max={event.ticketsAvailable || 99}
-                          value={quantity}
-                          onChange={(e) => {
-                            setQuantity(e.target.value);
-                            setAwaitingConfirm(false);
-                          }}
-                          onBlur={(e) => {
-                            const val = parseInt(e.target.value, 10);
-                            setQuantity(String(isNaN(val) || val < 1 ? 1 : val));
-                          }}
-                          className="glass-input"
-                        />
-                        {event.ticketPrice > 0 && (
-                          <p className="text-sm text-base-content/70 mt-1">
-                            Total: £{(event.ticketPrice * (parseInt(quantity) || 1)).toFixed(2)}
-                          </p>
-                        )}
-                        {awaitingConfirm && (
-                          <div className="mt-3 bg-amber-50 border border-amber-200 rounded-xl p-3">
-                            <p className="text-sm font-medium text-amber-700 mb-2">
-                              You're buying {quantity} tickets — are you sure?
-                            </p>
-                            <div className="flex gap-2">
-                              <button
-                                onClick={() => {
-                                  setAwaitingConfirm(false);
-                                  setQuantity(1);
-                                }}
-                                className="flex-1 text-xs py-1.5 rounded-lg border border-amber-300 text-amber-700 hover:bg-amber-100 transition-all cursor-pointer"
-                              >
-                                Change
-                              </button>
-                              <button
-                                onClick={handleBuyTickets}
-                                className="flex-1 text-xs py-1.5 rounded-lg bg-amber-500 text-white hover:bg-amber-600 transition-all font-medium cursor-pointer"
-                              >
-                                Yes, continue
-                              </button>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {buyError && (
-                      <p className="text-red-500 text-sm bg-red-50/50 rounded-xl p-2">{buyError}</p>
-                    )}
-
-                    <div className="pt-2">
-                      <Button
-                        variant="primary"
-                        className="w-full"
-                        onClick={handleBuyTickets}
-                        disabled={isProcessing || event.ticketsAvailable === 0}
-                      >
-                        {isProcessing ? (
-                          <span className="flex items-center justify-center">
-                            <Spinner size="sm" />
-                            <span className="ml-3">Redirecting to payment...</span>
-                          </span>
-                        ) : event.ticketsAvailable === 0 ? (
-                          "Sold Out"
-                        ) : event.isTournament ? (
-                          "Register & Pay for Team"
-                        ) : (
-                          "Buy Tickets"
-                        )}
-                      </Button>
-                    </div>
-
-                    {/* Stripe badge */}
-                    {!event.isTournament && (
-                      <p className="text-xs text-center text-base-content/50 mt-2">
-                        Secure payment via Stripe
-                      </p>
-                    )}
-                  </div>
-                </div>
-              </GlassCard>
+              <TicketPurchaseForm
+                event={event}
+                eventId={eventId}
+                onTournamentSignup={handleTournamentSignup}
+              />
             ) : (
               <GlassCard className="bg-red-100/30 shadow-xl border-red-300/50">
                 <div className="card-body">
@@ -523,23 +154,26 @@ export default function EventDetails() {
               </GlassCard>
             )}
           </div>
+
+          {/* Left column on desktop, second on mobile: Event Details */}
+          <div className="md:col-span-2 md:order-1 space-y-6">
+            <EventInfoGrid event={event} />
+
+            <GlassCard className="shadow-xl">
+              <div className="card-body">
+                <h2 className="card-title text-xl text-base-content">About This Event</h2>
+                <div className="prose max-w-none text-base-content/80">
+                  <p>{event.longDescription}</p>
+                </div>
+              </div>
+            </GlassCard>
+
+            {isTournament && <MyTeamsSection teams={myTeams} />}
+          </div>
         </div>
 
-        {/* TeamSignupForm Modal */}
-        {showTeamSignup && (
-          <TeamSignupForm
-            eventId={eventId}
-            managerId={email}
-            onSuccess={() => {
-              setShowTeamSignup(false);
-              queryClient.invalidateQueries({ queryKey: ["my-teams", eventId] });
-            }}
-            onClose={() => setShowTeamSignup(false)}
-          />
-        )}
-
-        {/* Back Button */}
-        <div className="mt-8 mb-4">
+        {/* Share + Back row */}
+        <div className="mt-8 mb-4 flex items-center justify-between gap-3 flex-wrap">
           <Button variant="secondary" onClick={handleBack}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -557,127 +191,38 @@ export default function EventDetails() {
             </svg>
             Back to Events
           </Button>
-        </div>
-      </div>
-    </PageContainer>
-  );
-}
-
-function MyTeamRow({ team, onTeamUpdated }) {
-  const [expanded, setExpanded] = useState(false);
-  const [editing, setEditing] = useState(false);
-  const hasMem = team.members?.length > 0;
-
-  return (
-    <>
-      <div className="bg-white rounded-2xl border border-base-300 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden">
-        <div
-          onClick={() => hasMem && setExpanded((v) => !v)}
-          className={`flex items-center px-5 py-4 gap-4 transition-colors ${hasMem ? "cursor-pointer hover:bg-base-200/30" : ""}`}
-        >
-          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0">
+          <button
+            onClick={handleShare}
+            className="btn bg-[#1877F2] hover:bg-[#166FE5] text-white border-none shadow-md hover:shadow-lg transition-all duration-200"
+            aria-label="Share on Facebook"
+          >
             <svg
-              className="w-5 h-5 text-primary"
-              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
               viewBox="0 0 24 24"
-              stroke="currentColor"
+              fill="currentColor"
+              className="mr-1.5"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
-              />
+              <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z" />
             </svg>
-          </div>
-
-          <div className="flex-1 min-w-0">
-            <p className="font-semibold text-base-content truncate">{team.name}</p>
-            <p className="text-xs text-base-content/50 mt-0.5">
-              {team.members?.length ?? 0} member{team.members?.length !== 1 ? "s" : ""}
-              {team.manager?.phone && <span> · {team.manager.phone}</span>}
-            </p>
-          </div>
-
-          <div className="flex items-center gap-2 flex-shrink-0">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setEditing(true);
-              }}
-              className="btn btn-s bg-base-200/60 hover:bg-base-300/60 border border-base-300/60 text-base-content transition-all duration-300 rounded-lg"
-              title="Edit team"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-8 w-6"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                />
-              </svg>
-            </button>
-            <span
-              className={`text-xs font-medium px-2.5 py-0.5 rounded-full border ${team.paid ? "bg-green-50 text-green-700 border-green-200" : "bg-orange-50 text-orange-600 border-orange-200"}`}
-            >
-              {team.paid ? "Paid" : "Pending"}
-            </span>
-            {hasMem && (
-              <svg
-                className={`w-4 h-4 text-base-content/50 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
-            )}
-          </div>
+            Share on Facebook
+          </button>
         </div>
 
-        {hasMem && expanded && (
-          <div className="px-5 pb-4 pt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 border-t border-base-100">
-            {team.members.map((m, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-2.5 bg-base-200/40 rounded-xl px-3 py-2"
-              >
-                <div className="w-6 h-6 rounded-full bg-gradient-to-br from-primary to-primary/70 text-white text-[10px] font-bold flex items-center justify-center flex-shrink-0">
-                  {m.name?.[0]?.toUpperCase() ?? "?"}
-                </div>
-                <div className="min-w-0">
-                  <p className="text-xs font-medium text-base-content truncate">{m.name}</p>
-                  {m.email && (
-                    <p className="text-[10px] text-base-content/50 truncate">{m.email}</p>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+        {/* TeamSignupForm Modal */}
+        {showTeamSignup && (
+          <TeamSignupForm
+            eventId={eventId}
+            managerId={tournamentEmail}
+            onSuccess={() => {
+              setShowTeamSignup(false);
+              queryClient.invalidateQueries({ queryKey: ["my-teams", eventId] });
+            }}
+            onClose={() => setShowTeamSignup(false)}
+          />
         )}
       </div>
-
-      {editing && (
-        <TeamEditForm
-          team={team}
-          onClose={() => setEditing(false)}
-          onSaved={() => {
-            setEditing(false);
-            onTeamUpdated();
-          }}
-        />
-      )}
-    </>
+    </PageContainer>
   );
 }

--- a/src/pages/payments/CancelPage.jsx
+++ b/src/pages/payments/CancelPage.jsx
@@ -31,7 +31,21 @@ export default function CancelPage() {
         <p className="text-base-content mb-8">
           Your transaction has been cancelled. If this was a mistake, you can try again.
         </p>
-        <Button variant="primary" onClick={handleGoBack}>
+        <Button variant="secondary" onClick={handleGoBack}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5 mr-2"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
           Go Back to Home
         </Button>
       </GlassCard>

--- a/src/pages/tickets/TicketPage.jsx
+++ b/src/pages/tickets/TicketPage.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { Link, useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { isAuthenticated, getAuthToken } from "../../auth/auth";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { isAuthenticated, fetchWithAuth } from "../../auth/auth";
 import TicketCard from "../../components/tickets/TicketCard";
-import { PageContainer, GlassCard, Spinner } from "../../components/ui";
+import { Button, PageContainer, GlassCard, Spinner } from "../../components/ui";
 
 export default function TicketPage() {
   const { ticketCode } = useParams();
@@ -21,12 +21,9 @@ export default function TicketPage() {
       navigate("/login");
       return;
     }
-    const token = getAuthToken();
     Promise.all(
       codes.map((code) =>
-        fetch(`${import.meta.env.VITE_DEV_URI}tickets/${code}`, {
-          headers: { Authorization: "Bearer " + token },
-        }).then(async (res) => {
+        fetchWithAuth(`${import.meta.env.VITE_DEV_URI}tickets/${code}`).then(async (res) => {
           if (!res.ok) throw new Error(`Ticket ${code} not found`);
           return res.json();
         })
@@ -61,9 +58,23 @@ export default function TicketPage() {
       <PageContainer center>
         <GlassCard className="p-8 text-center max-w-sm border border-red-100">
           <p className="text-red-500 font-medium mb-4">{error}</p>
-          <Link to="/profile" className="text-sm text-base-content/70 hover:underline">
+          <Button variant="secondary" to="/profile">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
             Back to profile
-          </Link>
+          </Button>
         </GlassCard>
       </PageContainer>
     );
@@ -73,20 +84,25 @@ export default function TicketPage() {
   return (
     <PageContainer>
       <div className="max-w-lg mx-auto py-10 px-4">
-        <Link
-          to="/profile"
-          className="inline-flex items-center gap-1.5 text-sm text-base-content/50 hover:text-base-content/70 mb-6 transition-colors print:hidden"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 19l-7-7 7-7"
-            />
-          </svg>
-          Back to profile
-        </Link>
+        <div className="mb-6 print:hidden">
+          <Button variant="secondary" to="/profile">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 mr-2"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            Back to profile
+          </Button>
+        </div>
         {isMulti && (
           <p className="text-xs text-base-content/50 mb-4 print:hidden">
             Showing {tickets.length} tickets from this order

--- a/src/pages/tickets/TicketVerify.jsx
+++ b/src/pages/tickets/TicketVerify.jsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getAuthToken } from "../../auth/auth";
+import { fetchWithAuth } from "../../auth/auth";
 import { Button, PageContainer, Spinner, GlassCard } from "../../components/ui";
 
 const TICKET_CODE_RE = /^TKT-[A-Z2-9]{6}$/;
 
 const fetchTicket = async (ticketCode) => {
-  const response = await fetch(`${import.meta.env.VITE_DEV_URI}tickets/verify/${ticketCode}`, {
-    headers: { Authorization: `Bearer ${getAuthToken()}` },
-  });
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_DEV_URI}tickets/verify/${ticketCode}`
+  );
   if (!response.ok) {
     if (response.status === 401 || response.status === 403) throw new Error("AUTH_REQUIRED");
     if (response.status === 404) throw new Error("INVALID");
@@ -19,12 +19,9 @@ const fetchTicket = async (ticketCode) => {
 };
 
 const checkInTicket = async (ticketCode) => {
-  const response = await fetch(
+  const response = await fetchWithAuth(
     `${import.meta.env.VITE_DEV_URI}tickets/verify/${ticketCode}/checkin`,
-    {
-      method: "POST",
-      headers: { Authorization: `Bearer ${getAuthToken()}` },
-    }
+    { method: "POST" }
   );
   if (!response.ok) throw new Error("Failed to check in ticket");
   return response.json();

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -19,6 +19,47 @@ export const formatDate = (dateString) => {
   return `${year}-${month}-${day}`;
 };
 
+// Capitalised day name for a lowercase dayOfWeek value ("monday" → "Monday").
+export const capitalize = (str) => (str ? str.charAt(0).toUpperCase() + str.slice(1) : "");
+
+// Return the next upcoming occurrence of a recurring event from `fromDate` (default: now),
+// or null if the recurrence window has ended or the event isn't recurring.
+export const getNextRecurringDate = (event, fromDate = new Date()) => {
+  if (
+    !event?.isReoccurring ||
+    !event.reoccurringStartDate ||
+    !event.reoccurringEndDate ||
+    !event.dayOfWeek
+  ) {
+    return null;
+  }
+
+  const dayOfWeekMap = {
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6,
+    sunday: 0,
+  };
+
+  const start = new Date(event.reoccurringStartDate);
+  const end = new Date(event.reoccurringEndDate);
+  const targetDay = dayOfWeekMap[event.dayOfWeek.toLowerCase()];
+  if (targetDay === undefined) return null;
+
+  // Search from whichever is later — today or the series start.
+  let candidate = new Date(fromDate > start ? fromDate : start);
+  candidate.setHours(0, 0, 0, 0);
+
+  // Advance to the next target weekday (inclusive of today if today matches).
+  const diff = (targetDay - candidate.getDay() + 7) % 7;
+  candidate.setDate(candidate.getDate() + diff);
+
+  return candidate <= end ? candidate : null;
+};
+
 export const generateRecurringEvents = (event) => {
   if (
     !event.isReoccurring ||


### PR DESCRIPTION
…olbar, improve layout

- Split EventDetails into banner, info grid, ticket form, my-teams section
- Extract CourseDetails enrolled panel into EnrolledPanel component
- Lift MyTeamRow to shared component with readOnly prop; Profile owns team editing, event page shows read-only summary with 'Manage in Profile' CTA
- Add CourseHeader/CourseRoot mirroring EventHeader/EventRoot; toolbars now include Edit on detail pages alongside Create
- Mobile-first order swap: CTA column above fold on small screens
- Reserve image aspect-ratio to prevent CLS, standardize loading/error states, add prominent Facebook share button on both detail pages