### PR TITLE
Switch remove-participant to send participantId instead of index

### DIFF
--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -527,7 +527,7 @@ function EnrollmentRow({ enrollment }) {
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ participantIndex: index }),
+              body: JSON.stringify({ participantId: participants[index]._id }),
             }
           );
           const data = await res.json();


### PR DESCRIPTION
Backend now uses subdocument _id for stable participant references instead of array index which is fragile under concurrent modifications.