### PR TITLE
Responsive calendar for mobile + home page improvements

### DIFF
--- a/src/components/events/RecurringEventsCalendar.jsx
+++ b/src/components/events/RecurringEventsCalendar.jsx
@@ -1,105 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { Calendar, momentLocalizer } from "react-big-calendar";
 import moment from "moment";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import { useNavigate } from "react-router-dom";
 import { generateRecurringEvents, toSlug } from "../../util/util";
-
-const CustomToolbar = (toolbar) => {
-  const goToBack = () => {
-    const d = new Date(toolbar.date);
-    if (toolbar.view === "day") d.setDate(d.getDate() - 1);
-    else if (toolbar.view === "week") d.setDate(d.getDate() - 7);
-    else d.setMonth(d.getMonth() - 1);
-    toolbar.onNavigate("prev", d);
-  };
-  const goToNext = () => {
-    const d = new Date(toolbar.date);
-    if (toolbar.view === "day") d.setDate(d.getDate() + 1);
-    else if (toolbar.view === "week") d.setDate(d.getDate() + 7);
-    else d.setMonth(d.getMonth() + 1);
-    toolbar.onNavigate("next", d);
-  };
-  const goToCurrent = () => toolbar.onNavigate("TODAY");
-
-  return (
-    <div className="flex flex-wrap items-center justify-between mb-5 gap-3 py-5 px-3">
-      <div className="flex items-center gap-2">
-        <button
-          onClick={goToBack}
-          className="w-9 h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-base-200 border border-base-300 text-base-content hover:text-base-content/70 transition-all shadow-sm cursor-pointer"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fillRule="evenodd"
-              d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </button>
-        <button
-          onClick={goToCurrent}
-          className="px-4 h-9 rounded-xl bg-white/60 hover:bg-base-200 border border-base-300 text-base-content text-sm font-medium transition-all shadow-sm cursor-pointer"
-        >
-          Today
-        </button>
-        <button
-          onClick={goToNext}
-          className="w-9 h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-base-200 border border-base-300 text-base-content hover:text-base-content/70 transition-all shadow-sm cursor-pointer"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              fillRule="evenodd"
-              d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
-
-      <span className="font-bold text-base-content text-sm sm:text-lg">
-        {toolbar.view === "day" ? (
-          moment(toolbar.date).format("ddd, D MMMM YYYY")
-        ) : toolbar.view === "week" ? (
-          `${moment(toolbar.date).startOf("isoWeek").format("D MMM")} – ${moment(toolbar.date).endOf("isoWeek").format("D MMM YYYY")}`
-        ) : (
-          <>
-            {moment(toolbar.date).format("MMMM ")}
-            <span className="font-normal text-base-content/50">
-              {moment(toolbar.date).format("YYYY")}
-            </span>
-          </>
-        )}
-      </span>
-
-      <div className="flex items-center gap-1.5 bg-white/40 rounded-xl p-1 border border-white/60">
-        {toolbar.views.map((view) => (
-          <button
-            key={view}
-            onClick={() => toolbar.onView(view)}
-            className={`px-3 h-7 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer ${
-              view === toolbar.view
-                ? "bg-gradient-to-r from-primary to-secondary text-white shadow-sm"
-                : "text-base-content hover:bg-white/60"
-            }`}
-          >
-            {view.charAt(0).toUpperCase() + view.slice(1)}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-};
 
 moment.updateLocale("en", { week: { dow: 1 } });
 const localizer = momentLocalizer(moment);
@@ -118,26 +23,249 @@ function getEventColor(title) {
   return EVENT_COLORS[Math.abs(hash) % EVENT_COLORS.length];
 }
 
-function useCalendarHeight() {
-  const [height, setHeight] = useState(580);
-  React.useEffect(() => {
-    const update = () => {
-      const w = window.innerWidth;
-      if (w < 480) setHeight(350);
-      else if (w < 768) setHeight(420);
-      else setHeight(580);
+function useResponsive() {
+  const getState = () => {
+    const w = window.innerWidth;
+    return {
+      isMobile: w < 768,
+      calendarHeight: w < 480 ? 440 : w < 768 ? 500 : 580,
     };
-    update();
+  };
+  const [state, setState] = useState(getState);
+  useEffect(() => {
+    const update = () => setState(getState());
     window.addEventListener("resize", update);
     return () => window.removeEventListener("resize", update);
   }, []);
-  return height;
+  return state;
+}
+
+const VIEW_LABELS = { month: "Month", week: "Week", day: "Day", agenda: "List" };
+const TOOLBAR_HEIGHT = 70;
+
+function CustomToolbar({ date, view, views, onNavigate, onView }) {
+  const goToBack = () => {
+    const d = new Date(date);
+    if (view === "day") d.setDate(d.getDate() - 1);
+    else if (view === "week") d.setDate(d.getDate() - 7);
+    else d.setMonth(d.getMonth() - 1);
+    onNavigate("prev", d);
+  };
+  const goToNext = () => {
+    const d = new Date(date);
+    if (view === "day") d.setDate(d.getDate() + 1);
+    else if (view === "week") d.setDate(d.getDate() + 7);
+    else d.setMonth(d.getMonth() + 1);
+    onNavigate("next", d);
+  };
+  const goToCurrent = () => onNavigate("TODAY");
+
+  const titleContent =
+    view === "day" ? (
+      moment(date).format("ddd, D MMM YYYY")
+    ) : view === "week" ? (
+      `${moment(date).startOf("isoWeek").format("D MMM")} – ${moment(date).endOf("isoWeek").format("D MMM YYYY")}`
+    ) : (
+      <>
+        {moment(date).format("MMMM ")}
+        <span className="font-normal text-base-content/50">{moment(date).format("YYYY")}</span>
+      </>
+    );
+
+  return (
+    <div className="flex flex-col gap-2 py-3 px-2 sm:gap-0 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:py-5 sm:px-3 sm:mb-3">
+      <div className="sm:hidden text-center pb-1">
+        <span className="font-bold text-base-content text-[0.95rem]">{titleContent}</span>
+      </div>
+
+      <div className="flex items-center justify-between sm:justify-start gap-2">
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={goToBack}
+            className="w-10 h-10 sm:w-9 sm:h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-base-200 border border-base-300 text-base-content transition-all shadow-sm cursor-pointer"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={goToCurrent}
+            className="px-3 h-10 sm:h-9 rounded-xl bg-white/60 hover:bg-base-200 border border-base-300 text-base-content text-sm font-medium transition-all shadow-sm cursor-pointer"
+          >
+            Today
+          </button>
+          <button
+            onClick={goToNext}
+            className="w-10 h-10 sm:w-9 sm:h-9 flex items-center justify-center rounded-xl bg-white/60 hover:bg-base-200 border border-base-300 text-base-content transition-all shadow-sm cursor-pointer"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex sm:hidden items-center gap-1 bg-white/40 rounded-xl p-1 border border-white/60">
+          {views.map((v) => (
+            <button
+              key={v}
+              onClick={() => onView(v)}
+              className={`px-2.5 h-9 rounded-lg text-xs font-medium transition-all duration-200 cursor-pointer ${
+                v === view
+                  ? "bg-gradient-to-r from-primary to-secondary text-white shadow-sm"
+                  : "text-base-content hover:bg-white/60"
+              }`}
+            >
+              {VIEW_LABELS[v] || v.charAt(0).toUpperCase() + v.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <span className="hidden sm:block font-bold text-base-content text-lg">{titleContent}</span>
+
+      <div className="hidden sm:flex items-center gap-1.5 bg-white/40 rounded-xl p-1 border border-white/60">
+        {views.map((v) => (
+          <button
+            key={v}
+            onClick={() => onView(v)}
+            className={`px-3 h-7 rounded-lg text-sm font-medium transition-all duration-200 cursor-pointer ${
+              v === view
+                ? "bg-gradient-to-r from-primary to-secondary text-white shadow-sm"
+                : "text-base-content hover:bg-white/60"
+            }`}
+          >
+            {VIEW_LABELS[v] || v.charAt(0).toUpperCase() + v.slice(1)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EventListView({ events, navigate }) {
+  const grouped = {};
+  events.forEach((e) => {
+    const key = moment(e.start).format("YYYY-MM-DD");
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(e);
+  });
+  const sortedDates = Object.keys(grouped).sort();
+
+  if (sortedDates.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-base-content/40">
+        <svg className="w-12 h-12 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+        <p className="text-sm font-medium">No events this month</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {sortedDates.map((date) => (
+        <div key={date}>
+          <div className="sticky top-0 z-10 bg-base-100/95 backdrop-blur-sm px-3 py-2 text-xs font-bold text-primary uppercase tracking-wider border-b border-base-200/60">
+            {moment(date).format("dddd, D MMMM")}
+          </div>
+          {grouped[date].map((event, i) => {
+            const color = getEventColor(event.title);
+            return (
+              <button
+                key={event._id || i}
+                onClick={() => navigate(`/events/${toSlug(event.title, event._id)}`)}
+                className="w-full text-left px-3 py-3 hover:bg-white/60 active:bg-white/80 transition-colors flex items-center gap-3 cursor-pointer border-b border-base-200/30 last:border-b-0"
+              >
+                <div
+                  className="w-1 self-stretch rounded-full flex-shrink-0"
+                  style={{ backgroundColor: color.bg }}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="font-semibold text-sm text-base-content leading-snug">
+                    {event.isReoccurring && <span className="text-primary/60 mr-1">↻</span>}
+                    {event.title}
+                  </div>
+                  <div className="flex items-center gap-2 mt-1 text-xs text-base-content/60">
+                    {event.openingTime && <span>{event.openingTime}</span>}
+                    {event.openingTime && (event.street || event.city) && (
+                      <span className="text-base-content/30">·</span>
+                    )}
+                    {(event.street || event.city) && (
+                      <span className="truncate">
+                        {[event.street, event.city].filter(Boolean).join(", ")}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                {event.ticketPrice > 0 && (
+                  <span className="text-xs font-semibold text-secondary flex-shrink-0">
+                    £{event.ticketPrice}
+                  </span>
+                )}
+                <svg
+                  className="w-4 h-4 text-base-content/25 flex-shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export default function RecurringEventsCalendar({ events, title = "Events Calendar" }) {
   const navigate = useNavigate();
+  const { isMobile, calendarHeight } = useResponsive();
+
+  const [currentView, setCurrentView] = useState("month");
+  const [currentDate, setCurrentDate] = useState(() => new Date());
   const [selectedEvent, setSelectedEvent] = useState(null);
-  const calendarHeight = useCalendarHeight();
+  const [selectedDate, setSelectedDate] = useState(null);
+  const [selectedDateEvents, setSelectedDateEvents] = useState([]);
+
+  useEffect(() => {
+    if (isMobile && currentView === "week") setCurrentView("month");
+  }, [isMobile, currentView]);
+
+  const availableViews = isMobile ? ["month", "day", "agenda"] : ["month", "week", "day"];
+  const safeView = availableViews.includes(currentView) ? currentView : "month";
+  const isListView = safeView === "agenda";
+  const calendarViews = isMobile ? ["month", "day"] : ["month", "week", "day"];
 
   const expandedEvents = events.flatMap((event) =>
     event.isReoccurring ? generateRecurringEvents(event) : [event]
@@ -151,6 +279,54 @@ export default function RecurringEventsCalendar({ events, title = "Events Calend
     allDay: true,
   }));
 
+  const listEvents = calendarEvents
+    .filter((e) => moment(e.start).isSame(currentDate, "month"))
+    .sort((a, b) => a.start - b.start);
+
+  const handleToolbarNavigate = (action, date) => {
+    if (action === "TODAY") setCurrentDate(new Date());
+    else if (date) setCurrentDate(date);
+  };
+
+  const openDayPopup = (date) => {
+    const dayEvents = calendarEvents.filter((e) => moment(e.start).isSame(date, "day"));
+    if (dayEvents.length > 0) {
+      setSelectedDate(date);
+      setSelectedDateEvents(dayEvents);
+    }
+  };
+
+  const handleSelectEvent = (event) => {
+    if (isMobile) {
+      openDayPopup(event.start);
+    } else {
+      setSelectedEvent(event);
+    }
+  };
+
+  // Custom wrapper so tapping anywhere on a mobile day cell opens the popup
+  const MobileDateCellWrapper = ({ children, value }) => {
+    const isOffRange = !moment(value).isSame(currentDate, "month");
+    return (
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          position: "relative",
+          cursor: isOffRange ? "default" : "pointer",
+        }}
+        onClick={isOffRange ? undefined : () => openDayPopup(value)}
+      >
+        {children}
+      </div>
+    );
+  };
+
+  const handleConfirmNavigate = () => {
+    if (selectedEvent) navigate(`/events/${toSlug(selectedEvent.title, selectedEvent._id)}`);
+    setSelectedEvent(null);
+  };
+
   const dayPropGetter = (date) => {
     const isToday = moment().isSame(date, "day");
     const isCurrentMonth = moment(date).month() === moment().month();
@@ -163,21 +339,15 @@ export default function RecurringEventsCalendar({ events, title = "Events Calend
           boxShadow: "inset 0 0 0 2px rgba(37, 99, 235, 0.5)",
         },
       };
-    if (hasEvent)
-      return {
-        style: {
-          backgroundColor: "rgba(59, 130, 246, 0.08)",
-        },
-      };
+    if (hasEvent) return { style: { backgroundColor: "rgba(59, 130, 246, 0.08)" } };
     if (!isCurrentMonth)
-      return {
-        style: { backgroundColor: "rgba(249, 250, 251, 0.4)", color: "#a1a1aa" },
-      };
+      return { style: { backgroundColor: "rgba(249, 250, 251, 0.4)", color: "#a1a1aa" } };
     return {};
   };
 
   const eventStyleGetter = (event) => {
     const color = getEventColor(event.title);
+    const isOffRange = isMobile && !moment(event.start).isSame(currentDate, "month");
     return {
       style: {
         background: `linear-gradient(135deg, ${color.bg}, ${color.bg}dd)`,
@@ -191,14 +361,9 @@ export default function RecurringEventsCalendar({ events, title = "Events Calend
         overflow: "hidden",
         fontSize: "0.75rem",
         lineHeight: "1.4",
+        opacity: isOffRange ? 0.3 : 1,
       },
     };
-  };
-
-  const handleSelectEvent = (event) => setSelectedEvent(event);
-  const handleConfirmNavigate = () => {
-    if (selectedEvent) navigate(`/events/${toSlug(selectedEvent.title, selectedEvent._id)}`);
-    setSelectedEvent(null);
   };
 
   return (
@@ -209,85 +374,300 @@ export default function RecurringEventsCalendar({ events, title = "Events Calend
           <h2 className="text-xl sm:text-2xl font-bold text-base-content">{title}</h2>
           <div className="h-1 w-16 bg-gradient-to-r from-primary to-secondary rounded-full mt-1.5"></div>
         </div>
-        <div className="flex items-center gap-3 sm:gap-4 text-xs text-base-content/50">
-          <span className="flex items-center gap-1.5">
-            <span className="w-3.5 h-3.5 rounded-full bg-primary/20 border-2 border-primary inline-block"></span>
-            Today
-          </span>
-          <span className="flex items-center gap-1.5">
-            <span className="w-3.5 h-3.5 rounded-full bg-secondary/30 border border-secondary inline-block"></span>
-            Has event
-          </span>
-        </div>
+        {!isListView && (
+          <div className="flex items-center gap-3 sm:gap-4 text-xs text-base-content/50">
+            <span className="flex items-center gap-1.5">
+              <span className="w-3.5 h-3.5 rounded-full bg-primary/20 border-2 border-primary inline-block"></span>
+              Today
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-3.5 h-3.5 rounded-full bg-secondary/30 border border-secondary inline-block"></span>
+              Has event
+            </span>
+          </div>
+        )}
       </div>
 
-      {/* Calendar */}
-      <div className="rounded-2xl overflow-hidden border border-white/40 shadow-inner bg-white/20 backdrop-blur-sm">
-        <Calendar
-          localizer={localizer}
-          events={calendarEvents}
-          startAccessor="start"
-          endAccessor="end"
-          style={{ height: calendarHeight, width: "100%", background: "transparent" }}
-          onSelectEvent={handleSelectEvent}
-          views={["month", "week", "day"]}
-          popup
-          dayLayoutAlgorithm="no-overlap"
-          dayPropGetter={dayPropGetter}
-          eventPropGetter={eventStyleGetter}
-          formats={{
-            dayHeaderFormat: (date) => moment(date).format("dddd, D MMMM YYYY"),
-            dayFormat: (date) => moment(date).format("ddd DD"),
-            weekdayFormat: (date) => moment(date).format("ddd D"),
-            monthHeaderFormat: (date) => moment(date).format("MMMM YYYY"),
-          }}
-          components={{
-            toolbar: CustomToolbar,
-            event: ({ event }) => (
-              <div
-                className="cursor-pointer overflow-hidden"
-                title={[event.title, event.openingTime, event.city].filter(Boolean).join(" · ")}
-              >
-                <div className="truncate text-[0.7rem] font-semibold leading-tight drop-shadow-sm">
-                  {event.isReoccurring && <span className="opacity-80">↻ </span>}
-                  {event.title}
-                </div>
-                {event.openingTime && (
-                  <div className="truncate text-[0.6rem] opacity-80 mt-px">{event.openingTime}</div>
-                )}
-              </div>
-            ),
-          }}
-        />
-      </div>
-
-      {/* Event detail popup */}
-      {selectedEvent && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
-          onClick={() => setSelectedEvent(null)}
-        >
-          {/* overflow-hidden so the top bar sits flush with no padding gap */}
-          <div
-            className="bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl border border-white/60 overflow-hidden max-w-sm w-full mx-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Coloured top bar — flush because parent has overflow-hidden, no negative margins needed */}
-            <div style={{ background: getEventColor(selectedEvent.title).bg, height: 6 }} />
-
-            <div className="p-6">
-              <div className="flex items-start justify-between mb-4">
-                <div className="flex-1">
-                  <h3 className="text-lg font-bold text-base-content">{selectedEvent.title}</h3>
-                  {selectedEvent.isReoccurring && (
-                    <span className="text-xs px-2 py-0.5 rounded-full bg-base-200 text-primary font-medium mt-1 inline-block">
-                      🔁 Recurring
-                    </span>
+      {/* Calendar / List */}
+      <div className="glass-calendar rounded-2xl overflow-hidden border border-white/40 shadow-inner bg-white/20 backdrop-blur-sm">
+        {isListView ? (
+          <>
+            <CustomToolbar
+              date={currentDate}
+              view={safeView}
+              views={availableViews}
+              onNavigate={handleToolbarNavigate}
+              onView={setCurrentView}
+            />
+            <div
+              style={{ height: calendarHeight - TOOLBAR_HEIGHT, overflow: "auto" }}
+              className="px-1 pb-2"
+            >
+              <EventListView events={listEvents} navigate={navigate} />
+            </div>
+          </>
+        ) : isMobile ? (
+          <>
+            <CustomToolbar
+              date={currentDate}
+              view={safeView}
+              views={availableViews}
+              onNavigate={handleToolbarNavigate}
+              onView={setCurrentView}
+            />
+            <Calendar
+              localizer={localizer}
+              events={calendarEvents}
+              startAccessor="start"
+              endAccessor="end"
+              date={currentDate}
+              onNavigate={(date) => setCurrentDate(new Date(date))}
+              view={safeView}
+              onView={setCurrentView}
+              style={{
+                height: calendarHeight - TOOLBAR_HEIGHT,
+                width: "100%",
+                background: "transparent",
+              }}
+              onSelectEvent={handleSelectEvent}
+              onDrillDown={(date) => openDayPopup(date)}
+              views={calendarViews}
+              popup={false}
+              dayLayoutAlgorithm="no-overlap"
+              dayPropGetter={dayPropGetter}
+              eventPropGetter={eventStyleGetter}
+              formats={{
+                dayHeaderFormat: (date) => moment(date).format("ddd, D MMM YYYY"),
+                dayFormat: (date) => moment(date).format("ddd D"),
+                weekdayFormat: (date) => moment(date).format("dd"),
+                monthHeaderFormat: (date) => moment(date).format("MMMM YYYY"),
+              }}
+              components={{
+                toolbar: () => null,
+                dateCellWrapper: MobileDateCellWrapper,
+                event: ({ event }) => (
+                  <div className="cursor-pointer overflow-hidden">
+                    <div className="truncate text-[0.7rem] font-semibold leading-tight drop-shadow-sm">
+                      {event.isReoccurring && <span className="opacity-80">↻ </span>}
+                      {event.title}
+                    </div>
+                  </div>
+                ),
+              }}
+            />
+          </>
+        ) : (
+          <Calendar
+            localizer={localizer}
+            events={calendarEvents}
+            startAccessor="start"
+            endAccessor="end"
+            style={{ height: calendarHeight, width: "100%", background: "transparent" }}
+            onSelectEvent={handleSelectEvent}
+            views={["month", "week", "day"]}
+            popup
+            dayLayoutAlgorithm="no-overlap"
+            dayPropGetter={dayPropGetter}
+            eventPropGetter={eventStyleGetter}
+            formats={{
+              dayHeaderFormat: (date) => moment(date).format("dddd, D MMMM YYYY"),
+              dayFormat: (date) => moment(date).format("ddd DD"),
+              weekdayFormat: (date) => moment(date).format("ddd D"),
+              monthHeaderFormat: (date) => moment(date).format("MMMM YYYY"),
+            }}
+            components={{
+              toolbar: CustomToolbar,
+              event: ({ event }) => (
+                <div
+                  className="cursor-pointer overflow-hidden"
+                  title={[event.title, event.openingTime, event.city].filter(Boolean).join(" · ")}
+                >
+                  <div className="truncate text-[0.75rem] font-semibold leading-tight drop-shadow-sm">
+                    {event.isReoccurring && <span className="opacity-80">↻ </span>}
+                    {event.title}
+                  </div>
+                  {event.openingTime && (
+                    <div className="truncate text-[0.6rem] opacity-80 mt-px">
+                      {event.openingTime}
+                    </div>
                   )}
                 </div>
+              ),
+            }}
+          />
+        )}
+      </div>
+
+      {/* Desktop: single event popup */}
+      {selectedEvent &&
+        !isMobile &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+            onClick={() => setSelectedEvent(null)}
+          >
+            <div
+              className="bg-white/90 backdrop-blur-md rounded-2xl shadow-2xl border border-white/60 overflow-hidden max-w-sm w-full mx-4"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div style={{ background: getEventColor(selectedEvent.title).bg, height: 6 }} />
+              <div className="p-6">
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex-1">
+                    <h3 className="text-lg font-bold text-base-content">{selectedEvent.title}</h3>
+                    {selectedEvent.isReoccurring && (
+                      <span className="text-xs px-2 py-0.5 rounded-full bg-base-200 text-primary font-medium mt-1 inline-block">
+                        ↻ Recurring
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => setSelectedEvent(null)}
+                    className="w-10 h-10 flex items-center justify-center text-base-content/50 hover:text-base-content/70 ml-2 transition-colors cursor-pointer rounded-lg hover:bg-base-200"
+                  >
+                    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <div className="space-y-2.5 text-sm text-base-content/70 mb-5">
+                  <div className="flex items-center gap-2.5">
+                    <svg
+                      className="w-4 h-4 text-primary flex-shrink-0"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                      />
+                    </svg>
+                    <span>{moment(selectedEvent.start).format("dddd, D MMMM YYYY")}</span>
+                  </div>
+                  {selectedEvent.openingTime && (
+                    <div className="flex items-center gap-2.5">
+                      <svg
+                        className="w-4 h-4 text-secondary flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                      </svg>
+                      <span>{selectedEvent.openingTime}</span>
+                    </div>
+                  )}
+                  {(selectedEvent.street || selectedEvent.city) && (
+                    <div className="flex items-center gap-2.5">
+                      <svg
+                        className="w-4 h-4 text-info flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                        />
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                      </svg>
+                      <span>
+                        {[selectedEvent.street, selectedEvent.city].filter(Boolean).join(", ")}
+                      </span>
+                    </div>
+                  )}
+                  {selectedEvent.ticketPrice > 0 && (
+                    <div className="flex items-center gap-2.5">
+                      <svg
+                        className="w-4 h-4 text-accent flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"
+                        />
+                      </svg>
+                      <span>
+                        £{selectedEvent.ticketPrice}{" "}
+                        {selectedEvent.isTournament ? "per team" : "per ticket"}
+                      </span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setSelectedEvent(null)}
+                    className="flex-1 py-2.5 rounded-xl border border-base-300 text-base-content/70 text-sm hover:bg-base-200 transition-all cursor-pointer"
+                  >
+                    Close
+                  </button>
+                  <button
+                    onClick={handleConfirmNavigate}
+                    className="flex-1 py-2.5 rounded-xl bg-gradient-to-r from-primary to-secondary text-white text-sm font-medium transition-all shadow-sm cursor-pointer"
+                  >
+                    View Details →
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+
+      {/* Mobile: day events popup */}
+      {selectedDate &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
+            onClick={() => setSelectedDate(null)}
+          >
+            <div
+              className="bg-white/95 backdrop-blur-md rounded-t-2xl sm:rounded-2xl shadow-2xl border border-white/60 w-full sm:max-w-sm sm:mx-4 max-h-[75vh] flex flex-col"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex justify-center pt-2 pb-1 sm:hidden">
+                <div className="w-8 h-1 rounded-full bg-base-300"></div>
+              </div>
+
+              <div className="flex items-center justify-between px-4 py-3 border-b border-base-200/50">
+                <div>
+                  <h3 className="font-bold text-base-content text-base">
+                    {moment(selectedDate).format("dddd, D MMMM")}
+                  </h3>
+                  <p className="text-xs text-base-content/50 mt-0.5">
+                    {selectedDateEvents.length} event
+                    {selectedDateEvents.length !== 1 ? "s" : ""}
+                  </p>
+                </div>
                 <button
-                  onClick={() => setSelectedEvent(null)}
-                  className="text-base-content/50 hover:text-base-content/70 ml-2 transition-colors cursor-pointer"
+                  onClick={() => setSelectedDate(null)}
+                  className="w-9 h-9 flex items-center justify-center text-base-content/50 hover:text-base-content/70 transition-colors cursor-pointer rounded-lg hover:bg-base-200"
                 >
                   <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path
@@ -300,108 +680,94 @@ export default function RecurringEventsCalendar({ events, title = "Events Calend
                 </button>
               </div>
 
-              <div className="space-y-2.5 text-sm text-base-content/70 mb-5">
-                <div className="flex items-center gap-2.5">
-                  <svg
-                    className="w-4 h-4 text-primary flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                  <span>{moment(selectedEvent.start).format("dddd, D MMMM YYYY")}</span>
-                </div>
-                {selectedEvent.openingTime && (
-                  <div className="flex items-center gap-2.5">
-                    <svg
-                      className="w-4 h-4 text-secondary flex-shrink-0"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
+              <div className="overflow-y-auto flex-1 px-2 py-2">
+                {selectedDateEvents.map((event, i) => {
+                  const color = getEventColor(event.title);
+                  return (
+                    <button
+                      key={event._id || i}
+                      onClick={() => {
+                        setSelectedDate(null);
+                        navigate(`/events/${toSlug(event.title, event._id)}`);
+                      }}
+                      className="w-full text-left p-3 rounded-xl hover:bg-base-100 active:bg-base-200 transition-colors flex items-center gap-3 cursor-pointer"
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                      <div
+                        className="w-1.5 h-10 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: color.bg }}
                       />
-                    </svg>
-                    <span>{selectedEvent.openingTime}</span>
-                  </div>
-                )}
-                {(selectedEvent.street || selectedEvent.city) && (
-                  <div className="flex items-center gap-2.5">
-                    <svg
-                      className="w-4 h-4 text-info flex-shrink-0"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                      />
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                      />
-                    </svg>
-                    <span>
-                      {[selectedEvent.street, selectedEvent.city].filter(Boolean).join(", ")}
-                    </span>
-                  </div>
-                )}
-                {selectedEvent.ticketPrice > 0 && (
-                  <div className="flex items-center gap-2.5">
-                    <svg
-                      className="w-4 h-4 text-accent flex-shrink-0"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"
-                      />
-                    </svg>
-                    <span>
-                      £{selectedEvent.ticketPrice}{" "}
-                      {selectedEvent.isTournament ? "per team" : "per ticket"}
-                    </span>
-                  </div>
-                )}
-              </div>
-
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setSelectedEvent(null)}
-                  className="flex-1 py-2 rounded-xl border border-base-300 text-base-content/70 text-sm hover:bg-base-200 transition-all cursor-pointer"
-                >
-                  Close
-                </button>
-                <button
-                  onClick={handleConfirmNavigate}
-                  className="flex-1 py-2 rounded-xl bg-gradient-to-r from-primary to-secondary text-white text-sm font-medium transition-all shadow-sm cursor-pointer"
-                >
-                  View Details →
-                </button>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-semibold text-sm text-base-content leading-tight">
+                          {event.isReoccurring && <span className="text-primary/60 mr-1">↻</span>}
+                          {event.title}
+                        </div>
+                        <div className="flex items-center gap-1.5 mt-1 text-xs text-base-content/55">
+                          {event.openingTime && (
+                            <span className="flex items-center gap-1">
+                              <svg
+                                className="w-3 h-3"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                                />
+                              </svg>
+                              {event.openingTime}
+                            </span>
+                          )}
+                          {(event.street || event.city) && (
+                            <span className="flex items-center gap-1 truncate">
+                              <svg
+                                className="w-3 h-3 flex-shrink-0"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                                />
+                              </svg>
+                              <span className="truncate">
+                                {[event.street, event.city].filter(Boolean).join(", ")}
+                              </span>
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {event.ticketPrice > 0 && (
+                        <span className="text-xs font-semibold text-secondary flex-shrink-0">
+                          £{event.ticketPrice}
+                        </span>
+                      )}
+                      <svg
+                        className="w-4 h-4 text-base-content/25 flex-shrink-0"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
+                        />
+                      </svg>
+                    </button>
+                  );
+                })}
               </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/custom-styles.css
+++ b/src/custom-styles.css
@@ -347,10 +347,6 @@ textarea.glass-input {
   color: var(--color-base-300) !important;
 }
 
-.glass-calendar .rbc-row {
-  min-height: 80px !important;
-}
-
 .glass-calendar .rbc-month-row {
   overflow: visible !important;
 }
@@ -495,11 +491,11 @@ textarea.glass-input {
   }
 
   .glass-calendar .rbc-calendar {
-    padding: 4px !important;
+    padding: 2px !important;
   }
 
   .glass-calendar .rbc-header {
-    padding: 4px 2px !important;
+    padding: 6px 2px !important;
     font-size: 0.7rem !important;
   }
 
@@ -508,32 +504,76 @@ textarea.glass-input {
     font-size: 0.7rem !important;
   }
 
-  .glass-calendar .rbc-event {
-    padding: 1px 4px !important;
-    font-size: 0.65rem !important;
+  /* Month view: turn events into colored pills */
+  .glass-calendar .rbc-month-view .rbc-event {
+    height: 4px !important;
+    max-height: 4px !important;
+    padding: 0 !important;
+    font-size: 0 !important;
+    line-height: 0 !important;
+    border-radius: 2px !important;
+    border-left: none !important;
+    margin: 1px 2px !important;
+    box-shadow: none !important;
+    overflow: hidden !important;
   }
 
+  .glass-calendar .rbc-month-view .rbc-event * {
+    display: none !important;
+  }
+
+  .glass-calendar .rbc-month-view .rbc-event:hover {
+    transform: none !important;
+    filter: brightness(1.15) !important;
+  }
+
+  /* Compact month rows so the full grid fits */
   .glass-calendar .rbc-row {
-    min-height: 50px !important;
+    min-height: auto !important;
+  }
+
+  .glass-calendar .rbc-month-row {
+    min-height: 40px !important;
+    overflow: hidden !important;
+  }
+
+  .glass-calendar .rbc-row-segment {
+    padding: 0 1px !important;
+  }
+
+  .glass-calendar .rbc-show-more {
+    display: none !important;
   }
 
   .glass-calendar .rbc-toolbar-label {
     font-size: 1rem !important;
   }
+
+  /* Day cells are tappable on mobile (handled by dateCellWrapper component) */
+  .glass-calendar .rbc-month-view .rbc-day-bg {
+    cursor: pointer !important;
+  }
 }
 
 @media (max-width: 480px) {
-  .glass-calendar .rbc-row {
-    min-height: 40px !important;
-  }
-
   .glass-calendar .rbc-header {
-    font-size: 0.6rem !important;
-    padding: 3px 1px !important;
+    font-size: 0.62rem !important;
+    padding: 4px 1px !important;
   }
 
-  .glass-calendar .rbc-event {
-    font-size: 0.55rem !important;
-    padding: 0 2px !important;
+  .glass-calendar .rbc-date-cell {
+    padding: 1px 3px !important;
+    font-size: 0.62rem !important;
+  }
+
+  .glass-calendar .rbc-month-view .rbc-event {
+    height: 3px !important;
+    max-height: 3px !important;
+    margin: 0.5px 1px !important;
+    border-radius: 1.5px !important;
+  }
+
+  .glass-calendar .rbc-month-row {
+    min-height: 34px !important;
   }
 }

--- a/src/pages/content/Home.jsx
+++ b/src/pages/content/Home.jsx
@@ -22,7 +22,7 @@ function mergeWithDefaults(saved) {
 
 function SectionHeader({ kicker, title, action }) {
   return (
-    <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+    <div className="mb-8 flex flex-col items-center text-center gap-4 md:flex-row md:items-end md:justify-between md:text-left">
       <div className="max-w-2xl">
         <span className="section-kicker mb-4">{kicker}</span>
         <h2 className="section-heading">{title}</h2>
@@ -146,7 +146,9 @@ export default function Home() {
     }
   };
 
-  const upcomingEvents = (events || []).filter((event) => new Date(event.date) >= new Date());
+  const upcomingEvents = (events || [])
+    .filter((event) => new Date(event.date) >= new Date())
+    .sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0));
   const availableCourses = (courses || []).filter((course) => course.enrollmentOpen).slice(0, 3);
   const heroImage = heroImagePreview || pageContent.heroImage;
 
@@ -356,7 +358,7 @@ export default function Home() {
           action={
             <Link
               to="/events/asc"
-              className="inline-flex items-center gap-2 rounded-full border border-base-300 bg-white/80 px-5 py-3 text-sm font-semibold text-base-content shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:text-primary"
+              className="self-center md:self-auto inline-flex items-center gap-2 rounded-full border border-base-300 bg-white/80 px-5 py-3 text-sm font-semibold text-base-content shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:text-primary"
             >
               View All Events
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -390,7 +392,7 @@ export default function Home() {
           action={
             <Link
               to="/courses"
-              className="inline-flex items-center gap-2 rounded-full border border-base-300 bg-white/80 px-5 py-3 text-sm font-semibold text-base-content shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:text-primary"
+              className="self-center md:self-auto inline-flex items-center gap-2 rounded-full border border-base-300 bg-white/80 px-5 py-3 text-sm font-semibold text-base-content shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/20 hover:text-primary"
             >
               View All Courses
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/pages/events/Events.jsx
+++ b/src/pages/events/Events.jsx
@@ -229,7 +229,7 @@ export default function EventPage() {
 
         {/* Calendar view */}
         {view === "calendar" && (
-          <div className="glass-card rounded-2xl shadow-xl backdrop-blur-md border border-white/30 p-6">
+          <div className="glass-card rounded-2xl shadow-xl backdrop-blur-md border border-white/30 p-3 sm:p-6">
             <RecurringEventsCalendar
               events={typeFiltered}
               title={


### PR DESCRIPTION
- Rewrite RecurringEventsCalendar with separate mobile/desktop render paths
- Mobile month view uses colored pills instead of event text
- Custom dateCellWrapper makes entire day cells tappable on mobile
- Day popup and event popup use React portals to escape stacking contexts
- Custom list view replaces built-in agenda with proper contrast
- Off-range event pills dimmed to 0.3 opacity on mobile
- Off-range days are non-clickable
- Featured events sorted first on home page
- Section headers and action buttons centered on mobile